### PR TITLE
PORT-5259-port-agent-report-run-back-to-port

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,10 +265,10 @@ helm repo update
 
 helm install my-port-agent port-labs/port-agent \
     --create-namespace --namespace port-agent \
+    --set env.normal=YOUR_PORT_CLIENT_ID \
+    --set env.secret.PORT_CLIENT_SECRET=YOUR_PORT_CLIENT_SECRET \
     --set env.normal.PORT_ORG_ID=YOUR_ORG_ID \
     --set env.normal.KAFKA_CONSUMER_GROUP_ID=YOUR_KAFKA_CONSUMER_GROUP \
-    --set env.secret.KAFKA_CONSUMER_USERNAME=YOUR_KAFKA_USERNAME \
-    --set env.secret.KAFKA_CONSUMER_PASSWORD=YOUR_KAFKA_PASSWORD \
     --set env.normal.KAFKA_CONSUMER_BROKERS=PORT_KAFKA_BROKERS \
     --set env.normal.STREAMER_NAME=KAFKA \
     --set env.normal.KAFKA_CONSUMER_AUTHENTICATION_MECHANISM=SCRAM-SHA-512 \
@@ -365,10 +365,10 @@ helm repo update
 
 helm install my-port-agent port-labs/port-agent \
     --create-namespace --namespace port-agent \
+    --set env.normal=YOUR_PORT_CLIENT_ID \
+    --set env.secret.PORT_CLIENT_SECRET=YOUR_PORT_CLIENT_SECRET \
     --set env.normal.PORT_ORG_ID=YOUR_ORG_ID \
     --set env.normal.KAFKA_CONSUMER_GROUP_ID=YOUR_KAFKA_CONSUMER_GROUP \
-    --set env.secret.KAFKA_CONSUMER_USERNAME=YOUR_KAFKA_USERNAME \
-    --set env.secret.KAFKA_CONSUMER_PASSWORD=YOUR_KAFKA_PASSWORD
     --set env.normal.KAFKA_CONSUMER_BROKERS=PORT_KAFKA_BROKERS \
     --set env.normal.STREAMER_NAME=KAFKA \
     --set env.normal.KAFKA_CONSUMER_AUTHENTICATION_MECHANISM=SCRAM-SHA-512 \

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Here is the mapping file schema:
       "report" { # Optional. Used to report the run status back to Port right after the request is sent to the 3rd party application
         "status": JQ, # Optional. Should return the wanted runs status
         "link": JQ, # Optional. Should return the wanted link or a list of links
+        "summary": JQ, # Optional. Should return the wanted summary
         "externalRunId": JQ # Optional. Should return the wanted external run id
       }
   }
@@ -144,6 +145,7 @@ The report mapping can use the following fields:
 `.body` - The incoming message as mentioned [Above](#the-incoming-message-to-base-your-mapping-on)
 `.request` - The request that was calculated using the control the payload mapping and sent to the 3rd party application 
 `.response` - The response that was received from the 3rd party application
+
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -248,8 +248,8 @@ Create the following blueprint, action and mapping to trigger a Terraform Cloud 
     },
     "report": {
       "status": "if .response.statusCode == 201 then \"SUCCESS\" else \"FAILURE\" end",
-      "link": "\"https://app.terraform.io/app/\" + .body.payload.entity.properties.organization_name + \"/workspaces/\" + .body.payload.entity.properties.workspace_name + \"/runs/\" + .response.jsonData.data.id",
-      "externalRunId": ".response.jsonData.data.id"
+      "link": "\"https://app.terraform.io/app/\" + .body.payload.entity.properties.organization_name + \"/workspaces/\" + .body.payload.entity.properties.workspace_name + \"/runs/\" + .response.json.data.id",
+      "externalRunId": ".response.json.data.id"
     }
   }
 ]

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ helm repo update
 
 helm install my-port-agent port-labs/port-agent \
     --create-namespace --namespace port-agent \
-    --set env.normal=YOUR_PORT_CLIENT_ID \
+    --set env.secret.PORT_CLIENT_ID=YOUR_PORT_CLIENT_ID \
     --set env.secret.PORT_CLIENT_SECRET=YOUR_PORT_CLIENT_SECRET \
     --set env.normal.PORT_ORG_ID=YOUR_ORG_ID \
     --set env.normal.KAFKA_CONSUMER_GROUP_ID=YOUR_KAFKA_CONSUMER_GROUP \
@@ -365,7 +365,7 @@ helm repo update
 
 helm install my-port-agent port-labs/port-agent \
     --create-namespace --namespace port-agent \
-    --set env.normal=YOUR_PORT_CLIENT_ID \
+    --set env.secret.PORT_CLIENT_ID=YOUR_PORT_CLIENT_ID \
     --set env.secret.PORT_CLIENT_SECRET=YOUR_PORT_CLIENT_SECRET \
     --set env.normal.PORT_ORG_ID=YOUR_ORG_ID \
     --set env.normal.KAFKA_CONSUMER_GROUP_ID=YOUR_KAFKA_CONSUMER_GROUP \

--- a/README.md
+++ b/README.md
@@ -133,6 +133,18 @@ Here is the mapping file schema:
 
 </details>
 
+
+### The report mapping
+
+After the request is sent to the 3rd party application, the Port agent can report the run status back to Port.
+The report mapping is used to construct the report that will be sent to Port.
+
+The report mapping can use the following fields:
+
+`.body` - The incoming message as mentioned [Above](#the-incoming-message-to-base-your-mapping-on)
+`.request` - The request that was calculated using the control the payload mapping and sent to the 3rd party application 
+`.response` - The response that was received from the 3rd party application
+
 ### Examples
 
 #### Terraform Cloud

--- a/app/consumers/kafka_consumer.py
+++ b/app/consumers/kafka_consumer.py
@@ -6,6 +6,7 @@ from confluent_kafka import Consumer, KafkaException, Message
 from consumers.base_consumer import BaseConsumer
 from core.config import settings
 from core.consts import consts
+from port_client import get_kafka_credentials
 
 logging.basicConfig(level=settings.LOG_LEVEL)
 logger = logging.getLogger(__name__)
@@ -24,13 +25,15 @@ class KafkaConsumer(BaseConsumer):
         if consumer:
             self.consumer = consumer
         else:
+            logger.info("Getting Kafka credentials")
+            username, password = get_kafka_credentials()
             conf = {
                 "bootstrap.servers": settings.KAFKA_CONSUMER_BROKERS,
                 "client.id": consts.KAFKA_CONSUMER_CLIENT_ID,
                 "security.protocol": settings.KAFKA_CONSUMER_SECURITY_PROTOCOL,
                 "sasl.mechanism": settings.KAFKA_CONSUMER_AUTHENTICATION_MECHANISM,
-                "sasl.username": settings.KAFKA_CONSUMER_USERNAME,
-                "sasl.password": settings.KAFKA_CONSUMER_PASSWORD,
+                "sasl.username": username,
+                "sasl.password": password,
                 "group.id": settings.KAFKA_CONSUMER_GROUP_ID,
                 "session.timeout.ms": settings.KAFKA_CONSUMER_SESSION_TIMEOUT_MS,
                 "auto.offset.reset": settings.KAFKA_CONSUMER_AUTO_OFFSET_RESET,

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,7 +1,22 @@
 from pathlib import Path
 from typing import Any, Literal, Optional
 
-from pydantic import BaseModel, BaseSettings, parse_file_as, validator
+from pydantic import (
+    AnyHttpUrl,
+    BaseModel,
+    BaseSettings,
+    Field,
+    parse_file_as,
+    parse_obj_as,
+    validator,
+)
+
+
+class ActionReport(BaseModel):
+    status: str | None = None
+    link: str | None = None
+    summary: str | None = None
+    external_run_id: str | None = Field(None, alias="externalRunId")
 
 
 class Mapping(BaseModel):
@@ -11,6 +26,7 @@ class Mapping(BaseModel):
     body: dict[str, Any] | str | None = None
     headers: dict[str, str] | str | None = None
     query: dict[str, str] | str | None = None
+    report: ActionReport | None = None
 
 
 class Settings(BaseSettings):
@@ -19,6 +35,9 @@ class Settings(BaseSettings):
     STREAMER_NAME: str
 
     PORT_ORG_ID: str
+    PORT_API_BASE_URL: AnyHttpUrl = parse_obj_as(AnyHttpUrl, "https://api.getport.io")
+    PORT_CLIENT_ID: str
+    PORT_CLIENT_SECRET: str
     KAFKA_CONSUMER_BROKERS: str = "localhost:9092"
     KAFKA_CONSUMER_SECURITY_PROTOCOL: str = "plaintext"
     KAFKA_CONSUMER_AUTHENTICATION_MECHANISM: str = "none"

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -41,8 +41,6 @@ class Settings(BaseSettings):
     KAFKA_CONSUMER_BROKERS: str = "localhost:9092"
     KAFKA_CONSUMER_SECURITY_PROTOCOL: str = "plaintext"
     KAFKA_CONSUMER_AUTHENTICATION_MECHANISM: str = "none"
-    KAFKA_CONSUMER_USERNAME: str = "local"
-    KAFKA_CONSUMER_PASSWORD: str = ""
     KAFKA_CONSUMER_SESSION_TIMEOUT_MS: int = 45000
     KAFKA_CONSUMER_AUTO_OFFSET_RESET: str = "earliest"
     KAFKA_CONSUMER_GROUP_ID: str = ""

--- a/app/invokers/webhook_invoker.py
+++ b/app/invokers/webhook_invoker.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from typing import Any, Callable
 
@@ -207,9 +208,10 @@ class WebhookInvoker(BaseInvoker):
         )
         run_logger("Reporting the run response")
 
-        response_value = response.text
-        if response.headers.get("Content-Type", "").startswith("application/json"):
+        try:
             response_value = response.json()
+        except json.JSONDecodeError:
+            response_value = response.text
 
         return report_run_response(run_id, response_value)
 

--- a/app/invokers/webhook_invoker.py
+++ b/app/invokers/webhook_invoker.py
@@ -1,5 +1,4 @@
 import logging
-from dataclasses import dataclass
 from typing import Any
 
 import pyjq as jq
@@ -8,18 +7,28 @@ from core.config import Mapping, control_the_payload_config, settings
 from core.consts import consts
 from flatten_dict import flatten, unflatten
 from invokers.base_invoker import BaseInvoker
+from port_client import report_run_status
+from pydantic import BaseModel, Field
+from requests import Response
+from utils import get_invocation_method_object, response_to_dict
 
 logging.basicConfig(level=settings.LOG_LEVEL)
 logger = logging.getLogger(__name__)
 
 
-@dataclass
-class RequestPayload:
+class RequestPayload(BaseModel):
     method: str
     url: str
     body: dict
     headers: dict
     query: dict
+
+
+class ReportPayload(BaseModel):
+    status: Any | None = None
+    link: Any | None = None
+    summary: Any | None = None
+    external_run_id: Any | None = Field(None, alias="externalRunId")
 
 
 class WebhookInvoker(BaseInvoker):
@@ -43,16 +52,59 @@ class WebhookInvoker(BaseInvoker):
         else:
             return self._jq_exec(mapping, body)
 
-    def _prepare_payload(self, body: dict, invocation_method: dict) -> RequestPayload:
+    def _prepare_payload(
+        self, mapping: Mapping | None, body: dict, invocation_method: dict
+    ) -> RequestPayload:
         request_payload: RequestPayload = RequestPayload(
-            consts.DEFAULT_HTTP_METHOD,
-            invocation_method.get("url", ""),
-            body,
-            {},
-            {},
+            method=invocation_method.get("method", consts.DEFAULT_HTTP_METHOD),
+            url=invocation_method.get("url", ""),
+            body=body,
+            headers={},
+            query={},
         )
+        if not mapping:
+            return request_payload
 
-        mapping: Mapping | None = next(
+        raw_mapping: dict = mapping.dict(exclude_none=True)
+        raw_mapping.pop("enabled")
+        raw_mapping.pop("report", None)
+        for key, value in raw_mapping.items():
+            result = self._apply_jq_on_field(value, body)
+            setattr(request_payload, key, result)
+
+        return request_payload
+
+    def _prepare_report(
+        self,
+        mapping: Mapping | None,
+        response_context: Response,
+        request_context: dict,
+        body_context: dict,
+    ) -> ReportPayload:
+        default_status = (
+            ("SUCCESS" if response_context.ok else "FAILURE")
+            if get_invocation_method_object(body_context).get("synchronized")
+            else None
+        )
+        report_payload: ReportPayload = ReportPayload(status=default_status)
+        if not mapping or not mapping.report:
+            return report_payload
+
+        context = {
+            "body": body_context,
+            "request": request_context,
+            "response": response_to_dict(response_context),
+        }
+
+        raw_mapping: dict = mapping.report.dict(exclude_none=True)
+        for key, value in raw_mapping.items():
+            result = self._apply_jq_on_field(value, context)
+            setattr(report_payload, key, result)
+
+        return report_payload
+
+    def _find_mapping(self, body: dict) -> Mapping:
+        return next(
             (
                 action_mapping
                 for action_mapping in control_the_payload_config
@@ -65,20 +117,7 @@ class WebhookInvoker(BaseInvoker):
             None,
         )
 
-        if not mapping:
-            return request_payload
-
-        raw_mapping: dict = mapping.dict(exclude_none=True)
-        raw_mapping.pop("enabled")
-        for key, value in raw_mapping.items():
-            result = self._apply_jq_on_field(value, body)
-            setattr(request_payload, key, result)
-
-        return request_payload
-
-    def invoke(self, body: dict, invocation_method: dict) -> None:
-        logger.info("WebhookInvoker - start - destination: %s", invocation_method)
-        request_payload = self._prepare_payload(body, invocation_method)
+    def request(self, request_payload: RequestPayload) -> Response:
         logger.info(
             "WebhookInvoker - request - " "method: %s, url: %s",
             request_payload.method,
@@ -92,11 +131,27 @@ class WebhookInvoker(BaseInvoker):
             params=request_payload.query,
             timeout=settings.WEBHOOK_INVOKER_TIMEOUT,
         )
+        return res
+
+    def invoke(self, body: dict, invocation_method: dict) -> None:
+        logger.info("WebhookInvoker - start - destination: %s", invocation_method)
+        mapping = self._find_mapping(body)
+
+        request_payload = self._prepare_payload(mapping, body, invocation_method)
+        res = self.request(request_payload)
         logger.info(
-            "WebhookInvoker - done - destination: %s, status code: %s",
+            "WebhookInvoker - request - destination: %s, status code: %s",
             invocation_method,
             res.status_code,
         )
+
+        run_id = body["context"]["runId"]
+        report_payload = self._prepare_report(
+            mapping, res, request_payload.dict(), body
+        )
+        if report_dict := report_payload.dict(exclude_none=True, by_alias=True):
+            report_run_status(run_id, report_dict)
+
         res.raise_for_status()
 
 

--- a/app/invokers/webhook_invoker.py
+++ b/app/invokers/webhook_invoker.py
@@ -164,11 +164,6 @@ class WebhookInvoker(BaseInvoker):
     def _report_run_status(
         run_id: str, data_to_patch: dict, run_logger: Callable[[str], None]
     ) -> Response:
-        logger.info(
-            "WebhookInvoker - report run - run_id: %s, data_to_patch: %s",
-            run_id,
-            data_to_patch,
-        )
         run_logger("Reporting the run status")
         res = report_run_status(run_id, data_to_patch)
 

--- a/app/invokers/webhook_invoker.py
+++ b/app/invokers/webhook_invoker.py
@@ -173,10 +173,7 @@ class WebhookInvoker(BaseInvoker):
                 run_id,
                 res.status_code,
             )
-            run_logger(
-                f"The run status was reported successfully "
-                f"with status code: {res.status_code}"
-            )
+            run_logger("The run status was reported successfully")
         else:
             logger.warning(
                 "WebhookInvoker - report run - "
@@ -208,7 +205,29 @@ class WebhookInvoker(BaseInvoker):
         except json.JSONDecodeError:
             response_value = response.text
 
-        return report_run_response(run_id, response_value)
+        res = report_run_response(run_id, response_value)
+
+        if res.ok:
+            logger.info(
+                "WebhookInvoker - report run response - " "run_id: %s, status_code: %s",
+                run_id,
+                res.status_code,
+            )
+            run_logger("The run response was reported successfully ")
+        else:
+            logger.warning(
+                "WebhookInvoker - report run response - "
+                "run_id: %s, status_code: %s, response: %s",
+                run_id,
+                res.status_code,
+                res.text,
+            )
+            run_logger(
+                f"The run response failed to be reported "
+                f"with status code: {res.status_code} and response: {res.text}"
+            )
+
+        return res
 
     def invoke(self, body: dict, invocation_method: dict) -> None:
         run_id = body["context"]["runId"]
@@ -232,11 +251,11 @@ class WebhookInvoker(BaseInvoker):
         report_payload = self._prepare_report(
             mapping, res, request_payload.dict(), body
         )
-        logger.info(
-            "WebhookInvoker - report mapping - report_payload: %s",
-            report_payload.dict(exclude_none=True, by_alias=True),
-        )
         if report_dict := report_payload.dict(exclude_none=True, by_alias=True):
+            logger.info(
+                "WebhookInvoker - report mapping - report_payload: %s",
+                report_payload.dict(exclude_none=True, by_alias=True),
+            )
             self._report_run_status(run_id, report_dict, run_logger)
         else:
             logger.info(

--- a/app/invokers/webhook_invoker.py
+++ b/app/invokers/webhook_invoker.py
@@ -10,7 +10,7 @@ from requests import Response
 from core.config import Mapping, control_the_payload_config, settings
 from core.consts import consts
 from invokers.base_invoker import BaseInvoker
-from port_client import report_run_status, send_run_log, run_logger_factory
+from port_client import report_run_status, run_logger_factory
 from utils import get_invocation_method_object, response_to_dict
 
 logging.basicConfig(level=settings.LOG_LEVEL)

--- a/app/port_client.py
+++ b/app/port_client.py
@@ -64,3 +64,13 @@ def report_run_response(run_id: str, response: dict | str) -> Response:
         headers=headers,
     )
     return res
+
+
+def get_kafka_credentials() -> tuple[str, str]:
+    headers = get_port_api_headers()
+    res = requests.get(
+        f"{settings.PORT_API_BASE_URL}/v1/kafka-credentials", headers=headers
+    )
+    res.raise_for_status()
+    data = res.json()["credentials"]
+    return data["username"], data["password"]

--- a/app/port_client.py
+++ b/app/port_client.py
@@ -1,4 +1,5 @@
 from logging import getLogger
+from typing import Callable
 
 import requests
 from core.config import settings
@@ -19,7 +20,8 @@ def get_port_api_headers() -> dict[str, str]:
 
     if not token_response.ok:
         logger.error(
-            f"Failed to get Port API access token - status: {token_response.status_code}, "
+            f"Failed to get Port API access token - "
+            f"status: {token_response.status_code}, "
             f"response: {token_response.text}"
         )
 
@@ -31,11 +33,11 @@ def get_port_api_headers() -> dict[str, str]:
     }
 
 
-def run_logger_factory(run_id: str):
+def run_logger_factory(run_id: str) -> Callable[[str], None]:
     def send_run_log(message: str) -> None:
         headers = get_port_api_headers()
 
-        res = requests.post(
+        requests.post(
             f"{settings.PORT_API_BASE_URL}/v1/actions/runs/{run_id}/logs",
             json={"message": message},
             headers=headers,

--- a/app/port_client.py
+++ b/app/port_client.py
@@ -32,19 +32,17 @@ def get_port_api_headers() -> dict[str, str]:
     }
 
 
-def send_run_log(run_id: str, message: str) -> None:
-    headers = get_port_api_headers()
+def run_logger_factory(run_id: str):
+    def send_run_log(message: str) -> None:
+        headers = get_port_api_headers()
 
-    res = requests.post(
-        f"{settings.PORT_API_BASE_URL}/actions/runs/{run_id}/logs",
-        json={"message": message},
-        headers=headers,
-    )
+        res = requests.post(
+            f"{settings.PORT_API_BASE_URL}/v1/actions/runs/{run_id}/logs",
+            json={"message": message},
+            headers=headers,
+        )
 
-    logger.info(
-        f"Send action run logs - status: {res.status_code}, "
-        f"body: {json.dumps(res.json())}"
-    )
+    return send_run_log
 
 
 def report_run_status(run_id: str, data_to_patch: dict) -> Response:

--- a/app/port_client.py
+++ b/app/port_client.py
@@ -1,0 +1,49 @@
+import json
+from logging import getLogger
+
+import requests
+from core.config import settings
+from requests import Response
+
+logger = getLogger(__name__)
+
+
+def get_port_api_headers() -> dict[str, str]:
+    credentials = {
+        "clientId": settings.PORT_CLIENT_ID,
+        "clientSecret": settings.PORT_CLIENT_SECRET,
+    }
+
+    token_response = requests.post(
+        f"{settings.PORT_API_BASE_URL}/v1/auth/access_token", json=credentials
+    )
+
+    return {
+        "Authorization": f"Bearer {token_response.json()['accessToken']}",
+        "User-Agent": "port-agent",
+    }
+
+
+def send_run_log(run_id: str, message: str) -> None:
+    headers = get_port_api_headers()
+
+    res = requests.post(
+        f"{settings.PORT_API_BASE_URL}/actions/runs/{run_id}/logs",
+        json={"message": message},
+        headers=headers,
+    )
+
+    logger.info(
+        f"Send action run logs - status: {res.status_code}, "
+        f"body: {json.dumps(res.json())}"
+    )
+
+
+def report_run_status(run_id: str, data_to_patch: dict) -> Response:
+    headers = get_port_api_headers()
+    res = requests.patch(
+        f"{settings.PORT_API_BASE_URL}/v1/actions/runs/{run_id}",
+        json=data_to_patch,
+        headers=headers,
+    )
+    return res

--- a/app/port_client.py
+++ b/app/port_client.py
@@ -54,3 +54,13 @@ def report_run_status(run_id: str, data_to_patch: dict) -> Response:
         headers=headers,
     )
     return res
+
+
+def report_run_response(run_id: str, response: dict | str) -> Response:
+    headers = get_port_api_headers()
+    res = requests.patch(
+        f"{settings.PORT_API_BASE_URL}/v1/actions/runs/{run_id}/response",
+        json={"response": response},
+        headers=headers,
+    )
+    return res

--- a/app/port_client.py
+++ b/app/port_client.py
@@ -1,4 +1,3 @@
-import json
 from logging import getLogger
 
 import requests

--- a/app/port_client.py
+++ b/app/port_client.py
@@ -18,6 +18,14 @@ def get_port_api_headers() -> dict[str, str]:
         f"{settings.PORT_API_BASE_URL}/v1/auth/access_token", json=credentials
     )
 
+    if not token_response.ok:
+        logger.error(
+            f"Failed to get Port API access token - status: {token_response.status_code}, "
+            f"response: {token_response.text}"
+        )
+
+    token_response.raise_for_status()
+
     return {
         "Authorization": f"Bearer {token_response.json()['accessToken']}",
         "User-Agent": "port-agent",

--- a/app/utils.py
+++ b/app/utils.py
@@ -6,12 +6,12 @@ def response_to_dict(response: Response) -> dict:
         "statusCode": response.status_code,
         "headers": dict(response.headers),
         "text": response.text,
-        "jsonData": None,
+        "json": None,
     }
 
     if response.ok:
         try:
-            response_dict["jsonData"] = response.json()
+            response_dict["json"] = response.json()
         except ValueError:
             pass
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,22 @@
+from requests import Response
+
+
+def response_to_dict(response: Response) -> dict:
+    response_dict = {
+        "statusCode": response.status_code,
+        "headers": dict(response.headers),
+        "text": response.text,
+        "jsonData": None,
+    }
+
+    if response.ok:
+        try:
+            response_dict["jsonData"] = response.json()
+        except ValueError:
+            pass
+
+    return response_dict
+
+
+def get_invocation_method_object(body: dict) -> dict:
+    return body.get("payload", {}).get("action", {}).get("invocationMethod", {})

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -3,4 +3,4 @@
 set -e
 set -x
 
-cd ./app && PYTHONPATH=./ STREAMER_NAME=test PORT_ORG_ID=test_org pytest --cov=./ --cov-report=term-missing ../tests "${@}"
+cd ./app && PYTHONPATH=./ STREAMER_NAME=test PORT_ORG_ID=test_org PORT_CLIENT_ID=test PORT_CLIENT_SECRET=test pytest --cov=./ --cov-report=term-missing ../tests "${@}"

--- a/tests/unit/processors/kafka/conftest.py
+++ b/tests/unit/processors/kafka/conftest.py
@@ -3,14 +3,13 @@ import os
 from signal import SIGINT
 from typing import Any, Callable, Generator, Optional
 
+import port_client
 import pytest
 import requests
 from _pytest.monkeypatch import MonkeyPatch
 from confluent_kafka import Consumer as _Consumer
-from pydantic import parse_obj_as
-
-import port_client
 from core.config import Mapping
+from pydantic import parse_obj_as
 
 
 @pytest.fixture
@@ -23,7 +22,7 @@ def mock_requests(monkeypatch: MonkeyPatch, request: Any) -> None:
             return request.param.get("json")
 
         @property
-        def ok(self):
+        def ok(self) -> bool:
             return 200 <= self.status_code <= 299
 
         def raise_for_status(self) -> None:
@@ -50,7 +49,7 @@ class Consumer(_Consumer):
         pass
 
     def subscribe(
-            self, topics: Any, on_assign: Any = None, *args: Any, **kwargs: Any
+        self, topics: Any, on_assign: Any = None, *args: Any, **kwargs: Any
     ) -> None:
         pass
 
@@ -83,7 +82,7 @@ def mock_kafka(monkeypatch: MonkeyPatch, request: Any) -> None:
             return request.getfixturevalue(request.param[0])(request.param[1])
 
     def mock_subscribe(
-            self: Any, topics: Any, on_assign: Any = None, *args: Any, **kwargs: Any
+        self: Any, topics: Any, on_assign: Any = None, *args: Any, **kwargs: Any
     ) -> None:
         pass
 

--- a/tests/unit/processors/kafka/conftest.py
+++ b/tests/unit/processors/kafka/conftest.py
@@ -7,8 +7,10 @@ import pytest
 import requests
 from _pytest.monkeypatch import MonkeyPatch
 from confluent_kafka import Consumer as _Consumer
-from core.config import Mapping
 from pydantic import parse_obj_as
+
+import port_client
+from core.config import Mapping
 
 
 @pytest.fixture
@@ -20,6 +22,10 @@ def mock_requests(monkeypatch: MonkeyPatch, request: Any) -> None:
         def json(self) -> dict:
             return request.param.get("json")
 
+        @property
+        def ok(self):
+            return 200 <= self.status_code <= 299
+
         def raise_for_status(self) -> None:
             if 400 <= self.status_code <= 599:
                 raise Exception(self.text)
@@ -27,6 +33,7 @@ def mock_requests(monkeypatch: MonkeyPatch, request: Any) -> None:
     def mock_request(*args: Any, **kwargs: Any) -> MockResponse:
         return MockResponse()
 
+    monkeypatch.setattr(port_client, "get_port_api_headers", lambda *args: {})
     monkeypatch.setattr(requests, "request", mock_request)
     monkeypatch.setattr(requests, "get", mock_request)
     monkeypatch.setattr(requests, "post", mock_request)
@@ -43,7 +50,7 @@ class Consumer(_Consumer):
         pass
 
     def subscribe(
-        self, topics: Any, on_assign: Any = None, *args: Any, **kwargs: Any
+            self, topics: Any, on_assign: Any = None, *args: Any, **kwargs: Any
     ) -> None:
         pass
 
@@ -76,7 +83,7 @@ def mock_kafka(monkeypatch: MonkeyPatch, request: Any) -> None:
             return request.getfixturevalue(request.param[0])(request.param[1])
 
     def mock_subscribe(
-        self: Any, topics: Any, on_assign: Any = None, *args: Any, **kwargs: Any
+            self: Any, topics: Any, on_assign: Any = None, *args: Any, **kwargs: Any
     ) -> None:
         pass
 

--- a/tests/unit/processors/kafka/conftest.py
+++ b/tests/unit/processors/kafka/conftest.py
@@ -17,6 +17,9 @@ def mock_requests(monkeypatch: MonkeyPatch, request: Any) -> None:
         status_code = request.param.get("status_code")
         text = "Invoker failed with status code: %d" % status_code
 
+        def json(self) -> dict:
+            return request.param.get("json")
+
         def raise_for_status(self) -> None:
             if 400 <= self.status_code <= 599:
                 raise Exception(self.text)
@@ -208,73 +211,6 @@ def mock_webhook_run_message(webhook_run_payload: dict) -> Callable[[dict], byte
     return get_run_message
 
 
-@pytest.fixture(scope="module")
-def mock_gitlab_run_message() -> Callable[[dict], bytes]:
-    run_message: dict = {
-        "action": "Create",
-        "resourceType": "run",
-        "status": "TRIGGERED",
-        "trigger": {
-            "by": {"orgId": "test_org", "userId": "test_user"},
-            "origin": "UI",
-            "at": "2022-11-16T16:31:32.447Z",
-        },
-        "context": {
-            "entity": None,
-            "blueprint": "Service",
-            "runId": "r_jE5FhDURh4Uen2Qr",
-        },
-        "payload": {
-            "entity": None,
-            "action": {
-                "id": "action_34aweFQtayw7SCVb",
-                "identifier": "Create",
-                "title": "Create",
-                "icon": "DefaultBlueprint",
-                "userInputs": {
-                    "properties": {
-                        "foo": {"type": "string", "description": "Description"},
-                        "bar": {"type": "number", "description": "Description"},
-                    },
-                    "required": [],
-                },
-                "invocationMethod": {
-                    "type": "GITLAB",
-                    "agent": True,
-                    "defaultRef": "main",
-                    "projectName": "project",
-                    "groupName": "group",
-                },
-                "trigger": "CREATE",
-                "description": "",
-                "blueprint": "Service",
-                "createdAt": "2022-11-15T09:58:52.863Z",
-                "createdBy": "test_user",
-                "updatedAt": "2022-11-15T09:58:52.863Z",
-                "updatedBy": "test_user",
-            },
-            "properties": {},
-        },
-    }
-
-    def get_gitlab_run_message(invocation_method: dict) -> bytes:
-        if invocation_method is not None:
-            run_message["payload"]["action"]["invocationMethod"] = invocation_method
-        return json.dumps(run_message).encode()
-
-    return get_gitlab_run_message
-
-
-@pytest.fixture
-def mock_gitlab_token(monkeypatch: MonkeyPatch) -> None:
-    monkeypatch.setenv("group_project", "token")
-
-
-@pytest.fixture
-def mock_gitlab_token_subgroup(monkeypatch: MonkeyPatch) -> None:
-    monkeypatch.setenv("group_subgroup_sub2_project", "token")
-
-
 @pytest.fixture()
 def mock_control_the_payload_config(monkeypatch: MonkeyPatch) -> list[dict[str, Any]]:
     mapping = [
@@ -293,6 +229,7 @@ def mock_control_the_payload_config(monkeypatch: MonkeyPatch) -> list[dict[str, 
                 "MY-HEADER": ".payload.action.identifier",
             },
             "query": {},
+            "report": {"link": '"http://test.com"'},
         },
     ]
     control_the_payload_config = parse_obj_as(list[Mapping], mapping)

--- a/tests/unit/processors/kafka/test_kafka_to_webhook_processor.py
+++ b/tests/unit/processors/kafka/test_kafka_to_webhook_processor.py
@@ -1,6 +1,6 @@
 from threading import Timer
 from unittest import mock
-from unittest.mock import ANY
+from unittest.mock import ANY, call
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
@@ -162,11 +162,21 @@ def test_invocation_method_synchronized(
             params=expected_query,
             timeout=settings.WEBHOOK_INVOKER_TIMEOUT,
         )
-        request_patch_mock.assert_called_once_with(
-            f"{settings.PORT_API_BASE_URL}/v1/actions/runs/"
-            f"{webhook_run_payload['context']['runId']}",
-            headers={},
-            json={"status": "SUCCESS"},
+        request_patch_mock.assert_has_calls(
+            calls=[
+                call(
+                    f"{settings.PORT_API_BASE_URL}/v1/actions/runs/"
+                    f"{webhook_run_payload['context']['runId']}/response",
+                    headers={},
+                    json=ANY,
+                ),
+                call(
+                    f"{settings.PORT_API_BASE_URL}/v1/actions/runs/"
+                    f"{webhook_run_payload['context']['runId']}",
+                    headers={},
+                    json={"status": "SUCCESS"},
+                ),
+            ]
         )
 
         mock_error.assert_not_called()

--- a/tests/unit/processors/kafka/test_kafka_to_webhook_processor.py
+++ b/tests/unit/processors/kafka/test_kafka_to_webhook_processor.py
@@ -58,7 +58,7 @@ def test_single_stream_failed(mock_requests: None, mock_kafka: None) -> None:
 
 @pytest.mark.parametrize(
     "mock_requests",
-    [{"status_code": 200, "json": {"accessToken": "test"}}],
+    [{"status_code": 200}],
     indirect=True,
 )
 @pytest.mark.parametrize(
@@ -105,7 +105,7 @@ def test_single_stream_success_control_the_payload(
         request_patch_mock.assert_called_once_with(
             f"{settings.PORT_API_BASE_URL}/v1/actions/runs/"
             f"{webhook_run_payload['context']['runId']}",
-            headers={"Authorization": "Bearer test", "User-Agent": "port-agent"},
+            headers={},
             json={"link": "http://test.com"},
         )
 
@@ -114,7 +114,7 @@ def test_single_stream_success_control_the_payload(
 
 @pytest.mark.parametrize(
     "mock_requests",
-    [{"status_code": 200, "json": {"accessToken": "test"}}],
+    [{"status_code": 200}],
     indirect=True,
 )
 @pytest.mark.parametrize(
@@ -165,7 +165,7 @@ def test_invocation_method_synchronized(
         request_patch_mock.assert_called_once_with(
             f"{settings.PORT_API_BASE_URL}/v1/actions/runs/"
             f"{webhook_run_payload['context']['runId']}",
-            headers={"Authorization": "Bearer test", "User-Agent": "port-agent"},
+            headers={},
             json={"status": "SUCCESS"},
         )
 

--- a/tests/unit/processors/kafka/test_kafka_to_webhook_processor.py
+++ b/tests/unit/processors/kafka/test_kafka_to_webhook_processor.py
@@ -167,15 +167,17 @@ def test_invocation_method_synchronized(
                 call(
                     f"{settings.PORT_API_BASE_URL}/v1/actions/runs/"
                     f"{webhook_run_payload['context']['runId']}/response",
-                    headers={},
                     json=ANY,
+                    headers={},
                 ),
+                call().ok.__bool__(),
                 call(
                     f"{settings.PORT_API_BASE_URL}/v1/actions/runs/"
                     f"{webhook_run_payload['context']['runId']}",
-                    headers={},
                     json={"status": "SUCCESS"},
+                    headers={},
                 ),
+                call().ok.__bool__()
             ]
         )
 

--- a/tests/unit/processors/kafka/test_kafka_to_webhook_processor.py
+++ b/tests/unit/processors/kafka/test_kafka_to_webhook_processor.py
@@ -177,7 +177,7 @@ def test_invocation_method_synchronized(
                     json={"status": "SUCCESS"},
                     headers={},
                 ),
-                call().ok.__bool__()
+                call().ok.__bool__(),
             ]
         )
 

--- a/tests/unit/processors/kafka/test_kafka_to_webhook_processor.py
+++ b/tests/unit/processors/kafka/test_kafka_to_webhook_processor.py
@@ -56,7 +56,11 @@ def test_single_stream_failed(mock_requests: None, mock_kafka: None) -> None:
         )
 
 
-@pytest.mark.parametrize("mock_requests", [{"status_code": 200}], indirect=True)
+@pytest.mark.parametrize(
+    "mock_requests",
+    [{"status_code": 200, "json": {"accessToken": "test"}}],
+    indirect=True,
+)
 @pytest.mark.parametrize(
     "mock_kafka",
     [
@@ -79,6 +83,11 @@ def test_single_stream_success_control_the_payload(
     expected_query: dict[str, ANY] = {}
     Timer(0.01, terminate_consumer).start()
     request_mock = mocker.patch("requests.request")
+    request_mock.return_value.headers = {}
+    request_mock.return_value.text = "test"
+    request_mock.return_value.status_code = 200
+    request_mock.return_value.json.return_value = {}
+    request_patch_mock = mocker.patch("requests.patch")
     mocker.patch("pathlib.Path.is_file", side_effect=(True,))
 
     with mock.patch.object(consumer_logger, "error") as mock_error:
@@ -86,6 +95,122 @@ def test_single_stream_success_control_the_payload(
         streamer.stream()
         request_mock.assert_called_once_with(
             "POST",
+            ANY,
+            json=expected_body,
+            headers=expected_headers,
+            params=expected_query,
+            timeout=settings.WEBHOOK_INVOKER_TIMEOUT,
+        )
+
+        request_patch_mock.assert_called_once_with(
+            f"{settings.PORT_API_BASE_URL}/v1/actions/runs/"
+            f"{webhook_run_payload['context']['runId']}",
+            headers={"Authorization": "Bearer test", "User-Agent": "port-agent"},
+            json={"link": "http://test.com"},
+        )
+
+        mock_error.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "mock_requests",
+    [{"status_code": 200, "json": {"accessToken": "test"}}],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "mock_kafka",
+    [
+        (
+            "mock_webhook_run_message",
+            {
+                "type": "WEBHOOK",
+                "agent": True,
+                "url": "http://localhost:80/api/test",
+                "synchronized": True,
+            },
+            settings.KAFKA_RUNS_TOPIC,
+        ),
+    ],
+    indirect=True,
+)
+def test_invocation_method_synchronized(
+    monkeypatch: MonkeyPatch,
+    mocker: MockFixture,
+    mock_requests: None,
+    mock_kafka: None,
+    mock_control_the_payload_config: list[Mapping],
+    webhook_run_payload: dict,
+) -> None:
+    expected_body = webhook_run_payload
+    expected_headers = {
+        "MY-HEADER": webhook_run_payload["payload"]["action"]["identifier"]
+    }
+    expected_query: dict[str, ANY] = {}
+    Timer(0.01, terminate_consumer).start()
+    request_mock = mocker.patch("requests.request")
+    request_patch_mock = mocker.patch("requests.patch")
+    mocker.patch("pathlib.Path.is_file", side_effect=(True,))
+
+    with mock.patch.object(consumer_logger, "error") as mock_error:
+        streamer = KafkaStreamer(Consumer())
+        streamer.stream()
+        request_mock.assert_called_once_with(
+            "POST",
+            ANY,
+            json=expected_body,
+            headers=expected_headers,
+            params=expected_query,
+            timeout=settings.WEBHOOK_INVOKER_TIMEOUT,
+        )
+        request_patch_mock.assert_called_once_with(
+            f"{settings.PORT_API_BASE_URL}/v1/actions/runs/"
+            f"{webhook_run_payload['context']['runId']}",
+            headers={"Authorization": "Bearer test", "User-Agent": "port-agent"},
+            json={"status": "SUCCESS"},
+        )
+
+        mock_error.assert_not_called()
+
+
+@pytest.mark.parametrize("mock_requests", [{"status_code": 200}], indirect=True)
+@pytest.mark.parametrize(
+    "mock_kafka",
+    [
+        (
+            "mock_webhook_run_message",
+            {
+                "type": "WEBHOOK",
+                "agent": True,
+                "url": "http://localhost:80/api/test",
+                "method": "GET",
+            },
+            settings.KAFKA_RUNS_TOPIC,
+        ),
+    ],
+    indirect=True,
+)
+def test_invocation_method_method_override(
+    monkeypatch: MonkeyPatch,
+    mocker: MockFixture,
+    mock_requests: None,
+    mock_kafka: None,
+    mock_control_the_payload_config: list[Mapping],
+    webhook_run_payload: dict,
+) -> None:
+    expected_body = webhook_run_payload
+    expected_headers = {
+        "MY-HEADER": webhook_run_payload["payload"]["action"]["identifier"]
+    }
+    expected_query: dict[str, ANY] = {}
+    Timer(0.01, terminate_consumer).start()
+    request_mock = mocker.patch("requests.request")
+    mocker.patch("pathlib.Path.is_file", side_effect=(True,))
+
+    with mock.patch.object(consumer_logger, "error") as mock_error:
+        streamer = KafkaStreamer(Consumer())
+        streamer.stream()
+        request_mock.assert_called_once_with(
+            "GET",
             ANY,
             json=expected_body,
             headers=expected_headers,

--- a/tests/unit/streamers/kafka/conftest.py
+++ b/tests/unit/streamers/kafka/conftest.py
@@ -3,12 +3,11 @@ import os
 from signal import SIGINT
 from typing import Any, Callable, Generator, Optional
 
+import port_client
 import pytest
 import requests
 from _pytest.monkeypatch import MonkeyPatch
 from confluent_kafka import Consumer as _Consumer
-
-import port_client
 
 
 @pytest.fixture
@@ -21,7 +20,7 @@ def mock_requests(monkeypatch: MonkeyPatch, request: Any) -> None:
             return request.param.get("json")
 
         @property
-        def ok(self):
+        def ok(self) -> bool:
             return 200 <= self.status_code <= 299
 
         def raise_for_status(self) -> None:


### PR DESCRIPTION
### The report mapping

After the request is sent to the 3rd party application, the Port agent can report the run status back to Port.
The report mapping is used to construct the report that will be sent to Port.

The report mapping can use the following fields:

`.body` - The incoming message as mentioned in the documentation
`.request` - The request that was calculated using the control the payload mapping and sent to the 3rd party application 
`.response` - The response that was received from the 3rd party application

```
[ 
  {
      ...,
      "report" { # Optional. Used to report the run status back to Port right after the request is sent to the 3rd party application
        "status": JQ, # Optional. Should return the wanted runs status
        "link": JQ, # Optional. Should return the wanted link or a list of links
        "summary": JQ, # Optional. Should return the wanted summary
        "externalRunId": JQ # Optional. Should return the wanted external run id
      }
  }
]
```