### PR TITLE
PORT-5949 updated the control the payload in the agent to use `"` instead of `'` in the default method value

### DIFF
--- a/app/control_the_payload_config.json
+++ b/app/control_the_payload_config.json
@@ -12,6 +12,6 @@
   {
     "enabled": true,
     "url": ".payload.action.invocationMethod.url",
-    "method": ".payload.action.invocationMethod.method // 'POST'"
+    "method": ".payload.action.invocationMethod.method // \"POST\""
   }
 ]


### PR DESCRIPTION
The port agent currently trying to use the default control the mapping json and fails to calculate the request method due to the default POST value being wrapped with `'` and not with `"`