### PR TITLE
brought back support for the changelog destination

### DIFF
--- a/app/control_the_payload_config.json
+++ b/app/control_the_payload_config.json
@@ -11,7 +11,7 @@
   },
   {
     "enabled": true,
-    "url": ".payload.action.invocationMethod.url",
+    "url": ".payload.action.invocationMethod.url // .changelogDestination.url",
     "method": ".payload.action.invocationMethod.method // \"POST\""
   }
 ]

--- a/app/invokers/webhook_invoker.py
+++ b/app/invokers/webhook_invoker.py
@@ -283,6 +283,7 @@ class WebhookInvoker(BaseInvoker):
 
         if run_id:
             self._invoke_run(run_id, mapping, body, invocation_method)
+        # Used for changelog destination event trigger
         elif invocation_method.get("url"):
             request_payload = self._prepare_payload(mapping, body, invocation_method)
             res = self._request(request_payload, lambda _: None)

--- a/app/invokers/webhook_invoker.py
+++ b/app/invokers/webhook_invoker.py
@@ -233,20 +233,9 @@ class WebhookInvoker(BaseInvoker):
 
         return res
 
-    def invoke(self, body: dict, invocation_method: dict) -> None:
-        run_id = body["context"]["runId"]
-
-        logger.info("WebhookInvoker - start - destination: %s", invocation_method)
-        mapping = self._find_mapping(body)
-        if mapping is None:
-            logger.info(
-                "WebhookInvoker - Could not find suitable mapping for the event"
-                " - run_id: %s, body: %s",
-                run_id,
-                body,
-            )
-            return
-
+    def _invoke_run(
+        self, run_id: str, mapping: Mapping, body: dict, invocation_method: dict
+    ) -> None:
         run_logger = run_logger_factory(run_id)
         run_logger("An action message has been received")
 
@@ -279,6 +268,31 @@ class WebhookInvoker(BaseInvoker):
             )
         res.raise_for_status()
         run_logger("Finished processing the action")
+
+    def invoke(self, body: dict, invocation_method: dict) -> None:
+        logger.info("WebhookInvoker - start - destination: %s", invocation_method)
+        run_id = body["context"].get("runId")
+
+        mapping = self._find_mapping(body)
+        if mapping is None:
+            logger.info(
+                "WebhookInvoker - Could not find suitable mapping for the event"
+                f" - body: {body} {', run_id: ' + run_id if run_id else ''}",
+            )
+            return
+
+        if run_id:
+            self._invoke_run(run_id, mapping, body, invocation_method)
+        elif invocation_method.get("url"):
+            request_payload = self._prepare_payload(mapping, body, invocation_method)
+            res = self._request(request_payload, lambda _: None)
+            res.raise_for_status()
+        else:
+            logger.warning(
+                "WebhookInvoker - Could not find suitable "
+                "invocation method for the event"
+            )
+        logger.info("Finished processing the event")
 
 
 webhook_invoker = WebhookInvoker()

--- a/tests/unit/processors/kafka/conftest.py
+++ b/tests/unit/processors/kafka/conftest.py
@@ -106,6 +106,8 @@ def mock_kafka(monkeypatch: MonkeyPatch, request: Any) -> None:
     monkeypatch.setattr(Consumer, "poll", mock_poll)
     monkeypatch.setattr(Consumer, "commit", mock_commit)
     monkeypatch.setattr(Consumer, "close", mock_close)
+    result_fixture = request.getfixturevalue(request.param[0])
+    return json.loads(result_fixture(request.param[1]).decode("utf-8"))
 
 
 @pytest.fixture(scope="module")
@@ -224,7 +226,7 @@ def mock_control_the_payload_config(monkeypatch: MonkeyPatch) -> list[dict[str, 
             "enabled": ".payload.non-existing-field",
             "body": ".",
             "headers": {
-                "MY-HEADER": ".payload.status",
+                "MY-HEADER": ".resourceType",
             },
             "query": {},
         },
@@ -232,7 +234,7 @@ def mock_control_the_payload_config(monkeypatch: MonkeyPatch) -> list[dict[str, 
             "enabled": True,
             "body": ".",
             "headers": {
-                "MY-HEADER": ".payload.action.identifier",
+                "MY-HEADER": ".resourceType",
             },
             "query": {},
             "report": {"link": '"http://test.com"'},

--- a/tests/unit/processors/kafka/test_kafka_to_webhook_processor.py
+++ b/tests/unit/processors/kafka/test_kafka_to_webhook_processor.py
@@ -77,7 +77,7 @@ def test_single_stream_success_control_the_payload(
     mock_control_the_payload_config: list[Mapping],
 ) -> None:
     expected_body = mock_kafka
-    expected_headers = {"MY-HEADER": "run"}
+    expected_headers = {"MY-HEADER": mock_kafka["resourceType"]}
     expected_query: dict[str, ANY] = {}
     Timer(0.01, terminate_consumer).start()
     request_mock = mocker.patch("requests.request")
@@ -132,7 +132,7 @@ def test_invocation_method_synchronized(
     webhook_run_payload: dict,
 ) -> None:
     expected_body = webhook_run_payload
-    expected_headers = {"MY-HEADER": "run"}
+    expected_headers = {"MY-HEADER": mock_kafka["resourceType"]}
     expected_query: dict[str, ANY] = {}
     Timer(0.01, terminate_consumer).start()
     request_mock = mocker.patch("requests.request")
@@ -207,7 +207,7 @@ def test_invocation_method_method_override(
     mock_control_the_payload_config: list[Mapping],
 ) -> None:
     expected_body = mock_kafka
-    expected_headers = {"MY-HEADER": "run"}
+    expected_headers = {"MY-HEADER": mock_kafka["resourceType"]}
     expected_query: dict[str, ANY] = {}
     Timer(0.01, terminate_consumer).start()
     request_mock = mocker.patch("requests.request")

--- a/tests/unit/processors/kafka/test_kafka_to_webhook_processor.py
+++ b/tests/unit/processors/kafka/test_kafka_to_webhook_processor.py
@@ -21,7 +21,7 @@ from tests.unit.processors.kafka.conftest import Consumer, terminate_consumer
     ],
     indirect=True,
 )
-def test_single_stream_success(mock_requests: None, mock_kafka: None) -> None:
+def test_single_stream_success(mock_requests: None, mock_kafka: dict) -> None:
     Timer(0.01, terminate_consumer).start()
 
     with mock.patch.object(consumer_logger, "error") as mock_error:
@@ -40,7 +40,7 @@ def test_single_stream_success(mock_requests: None, mock_kafka: None) -> None:
     ],
     indirect=True,
 )
-def test_single_stream_failed(mock_requests: None, mock_kafka: None) -> None:
+def test_single_stream_failed(mock_requests: None, mock_kafka: dict) -> None:
     Timer(0.01, terminate_consumer).start()
 
     with mock.patch.object(consumer_logger, "error") as mock_error:
@@ -64,6 +64,7 @@ def test_single_stream_failed(mock_requests: None, mock_kafka: None) -> None:
 @pytest.mark.parametrize(
     "mock_kafka",
     [
+        ("mock_webhook_change_log_message", None, settings.KAFKA_CHANGE_LOG_TOPIC),
         ("mock_webhook_run_message", None, settings.KAFKA_RUNS_TOPIC),
     ],
     indirect=True,
@@ -72,14 +73,11 @@ def test_single_stream_success_control_the_payload(
     monkeypatch: MonkeyPatch,
     mocker: MockFixture,
     mock_requests: None,
-    mock_kafka: None,
+    mock_kafka: dict,
     mock_control_the_payload_config: list[Mapping],
-    webhook_run_payload: dict,
 ) -> None:
-    expected_body = webhook_run_payload
-    expected_headers = {
-        "MY-HEADER": webhook_run_payload["payload"]["action"]["identifier"]
-    }
+    expected_body = mock_kafka
+    expected_headers = {"MY-HEADER": "run"}
     expected_query: dict[str, ANY] = {}
     Timer(0.01, terminate_consumer).start()
     request_mock = mocker.patch("requests.request")
@@ -87,7 +85,6 @@ def test_single_stream_success_control_the_payload(
     request_mock.return_value.text = "test"
     request_mock.return_value.status_code = 200
     request_mock.return_value.json.return_value = {}
-    request_patch_mock = mocker.patch("requests.patch")
     mocker.patch("pathlib.Path.is_file", side_effect=(True,))
 
     with mock.patch.object(consumer_logger, "error") as mock_error:
@@ -100,13 +97,6 @@ def test_single_stream_success_control_the_payload(
             headers=expected_headers,
             params=expected_query,
             timeout=settings.WEBHOOK_INVOKER_TIMEOUT,
-        )
-
-        request_patch_mock.assert_called_once_with(
-            f"{settings.PORT_API_BASE_URL}/v1/actions/runs/"
-            f"{webhook_run_payload['context']['runId']}",
-            headers={},
-            json={"link": "http://test.com"},
         )
 
         mock_error.assert_not_called()
@@ -137,14 +127,12 @@ def test_invocation_method_synchronized(
     monkeypatch: MonkeyPatch,
     mocker: MockFixture,
     mock_requests: None,
-    mock_kafka: None,
+    mock_kafka: dict,
     mock_control_the_payload_config: list[Mapping],
     webhook_run_payload: dict,
 ) -> None:
     expected_body = webhook_run_payload
-    expected_headers = {
-        "MY-HEADER": webhook_run_payload["payload"]["action"]["identifier"]
-    }
+    expected_headers = {"MY-HEADER": "run"}
     expected_query: dict[str, ANY] = {}
     Timer(0.01, terminate_consumer).start()
     request_mock = mocker.patch("requests.request")
@@ -189,6 +177,16 @@ def test_invocation_method_synchronized(
     "mock_kafka",
     [
         (
+            "mock_webhook_change_log_message",
+            {
+                "type": "WEBHOOK",
+                "agent": True,
+                "url": "http://localhost:80/api/test",
+                "method": "GET",
+            },
+            settings.KAFKA_CHANGE_LOG_TOPIC,
+        ),
+        (
             "mock_webhook_run_message",
             {
                 "type": "WEBHOOK",
@@ -205,14 +203,11 @@ def test_invocation_method_method_override(
     monkeypatch: MonkeyPatch,
     mocker: MockFixture,
     mock_requests: None,
-    mock_kafka: None,
+    mock_kafka: dict,
     mock_control_the_payload_config: list[Mapping],
-    webhook_run_payload: dict,
 ) -> None:
-    expected_body = webhook_run_payload
-    expected_headers = {
-        "MY-HEADER": webhook_run_payload["payload"]["action"]["identifier"]
-    }
+    expected_body = mock_kafka
+    expected_headers = {"MY-HEADER": "run"}
     expected_query: dict[str, ANY] = {}
     Timer(0.01, terminate_consumer).start()
     request_mock = mocker.patch("requests.request")


### PR DESCRIPTION
# Description

What - Triggering the agent using changelog destination fails due to incompatibility
Why - Forgot to support it on the previous versions
How - Made sure the code support other use cases then the run

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

