### PR TITLE
Port 6148 port agent automatically update action status on request failure

### DIFF
--- a/app/invokers/webhook_invoker.py
+++ b/app/invokers/webhook_invoker.py
@@ -88,8 +88,14 @@ class WebhookInvoker(BaseInvoker):
         success_status = "SUCCESS" if is_sync else None
         default_status = success_status if response_context.ok else "FAILURE"
 
-        default_summary = None if response_context.ok else f"Failed to invoke the webhook with status code: {response_context.status_code}. Response: {response_context.text}."
-        report_payload: ReportPayload = ReportPayload(status=default_status, summary=default_summary)
+        failure_summary = (
+            f"Failed to invoke the webhook with status code: "
+            f"{response_context.status_code}. Response: {response_context.text}."
+        )
+        default_summary = None if response_context.ok else failure_summary
+        report_payload: ReportPayload = ReportPayload(
+            status=default_status, summary=default_summary
+        )
         if not mapping or not mapping.report:
             return report_payload
 

--- a/app/invokers/webhook_invoker.py
+++ b/app/invokers/webhook_invoker.py
@@ -82,8 +82,10 @@ class WebhookInvoker(BaseInvoker):
         request_context: dict,
         body_context: dict,
     ) -> ReportPayload:
-        # We dont want to update the run status if the request succeeded and the invocation method is synchronized
-        success_status = "SUCCESS" if get_invocation_method_object(body_context).get("synchronized") else None
+        # We don't want to update the run status if the request succeeded and the
+        # invocation method is synchronized
+        is_sync = get_invocation_method_object(body_context).get("synchronized")
+        success_status = "SUCCESS" if is_sync else None
         default_status = success_status if response_context.ok else "FAILURE"
         report_payload: ReportPayload = ReportPayload(status=default_status)
         if not mapping or not mapping.report:

--- a/app/invokers/webhook_invoker.py
+++ b/app/invokers/webhook_invoker.py
@@ -82,11 +82,9 @@ class WebhookInvoker(BaseInvoker):
         request_context: dict,
         body_context: dict,
     ) -> ReportPayload:
-        default_status = (
-            ("SUCCESS" if response_context.ok else "FAILURE")
-            if get_invocation_method_object(body_context).get("synchronized")
-            else None
-        )
+        # We dont want to update the run status if the request succeeded and the invocation method is synchronized
+        success_status = "SUCCESS" if get_invocation_method_object(body_context).get("synchronized") else None
+        default_status = success_status if response_context.ok else "FAILURE"
         report_payload: ReportPayload = ReportPayload(status=default_status)
         if not mapping or not mapping.report:
             return report_payload

--- a/app/invokers/webhook_invoker.py
+++ b/app/invokers/webhook_invoker.py
@@ -87,7 +87,9 @@ class WebhookInvoker(BaseInvoker):
         is_sync = get_invocation_method_object(body_context).get("synchronized")
         success_status = "SUCCESS" if is_sync else None
         default_status = success_status if response_context.ok else "FAILURE"
-        report_payload: ReportPayload = ReportPayload(status=default_status)
+
+        default_summary = None if response_context.ok else f"Failed to invoke the webhook with status code: {response_context.status_code}. Response: {response_context.text}."
+        report_payload: ReportPayload = ReportPayload(status=default_status, summary=default_summary)
         if not mapping or not mapping.report:
             return report_payload
 


### PR DESCRIPTION
# Description

What - Action are left with In Progress status when the request failed
Why - There is no default status for failing request when the invocation is not synchronized true
How - Added default behavior

## Type of change

- [X] New feature (non-breaking change which adds functionality)

