### PR TITLE
Now adding the json context to the report parsing when possible

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -1,4 +1,8 @@
+import logging
+
 from requests import Response
+
+logger = logging.getLogger(__name__)
 
 
 def response_to_dict(response: Response) -> dict:
@@ -9,11 +13,12 @@ def response_to_dict(response: Response) -> dict:
         "json": None,
     }
 
-    if response.ok:
-        try:
-            response_dict["json"] = response.json()
-        except ValueError:
-            pass
+    try:
+        response_dict["json"] = response.json()
+    except ValueError:
+        logger.debug(
+            "Failed to parse response body as JSON: Response is not JSON serializable"
+        )
 
     return response_dict
 


### PR DESCRIPTION
# Description

What - When the request is failing the report does not contain the response json
Why - The code would not try to use it when the request status is not in the 200 - 300 status codes
How - Removed the status check and always trying to use the json if possible

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

