### PR TITLE
remove ensure ascii flags from json stringify to match js stringify

### DIFF
--- a/app/invokers/webhook_invoker.py
+++ b/app/invokers/webhook_invoker.py
@@ -297,9 +297,8 @@ class WebhookInvoker(BaseInvoker):
         # Remove the headers to avoid them being used in the signature verification
         del msg["headers"]["X-Port-Signature"]
         del msg["headers"]["X-Port-Timestamp"]
-
         expected_sig = sign_sha_256(
-            json.dumps(msg, separators=(",", ":")),
+            json.dumps(msg, separators=(",", ":"), ensure_ascii=False),
             settings.PORT_CLIENT_SECRET,
             port_timestamp,
         )


### PR DESCRIPTION
# Description

What - removes ensure ascii from json.dumps to match json.stringify in js
Why - cause we calculate hash on the non ascii chars and we have mismatch hash
How - removed the flag

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

