### PR TITLE
Update WEBHOOK_INVOKER_TIMEOUT type to float

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -69,7 +69,7 @@ class Settings(BaseSettings):
         env_file = find_dotenv()
         env_file_encoding = "utf-8"
 
-    WEBHOOK_INVOKER_TIMEOUT: int = 30
+    WEBHOOK_INVOKER_TIMEOUT: float = 30
 
 
 settings = Settings()


### PR DESCRIPTION
Changed the type of WEBHOOK_INVOKER_TIMEOUT from int to float to ensure proper handling of non-integer timeout values. This modification allows for more precise configuration and prevents potential type-related issues.

# Description

What - Changed the type of WEBHOOK_INVOKER_TIMEOUT from int to float
Why - This modification allows for handling of non-integer timeout values, providing more precise configuration options and preventing potential type-related issues
How - Updated the variable type in the configuration to float and verified compatibility with existing timeout-handling functions

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

