### PR TITLE
Improve Workflow node runs handling

### DIFF
--- a/app/consumers/http_polling_consumer.py
+++ b/app/consumers/http_polling_consumer.py
@@ -114,7 +114,7 @@ class HttpPollingConsumer(BaseConsumer):
                     process_fn=self.wf_node_run_process,
                     report_failure_fn=lambda run_id: report_wf_node_run_status(
                         run_id,
-                        {"status": "COMPLETED", "result": "FAILURE"},
+                        {"status": "COMPLETED", "result": "FAILED"},
                     ),
                 )
             )

--- a/app/consumers/kafka_consumer.py
+++ b/app/consumers/kafka_consumer.py
@@ -64,7 +64,6 @@ class KafkaConsumer(BaseConsumer):
                 [
                     settings.KAFKA_RUNS_TOPIC,
                     settings.KAFKA_CHANGE_LOG_TOPIC,
-                    settings.KAFKA_WF_NODE_RUNS_TOPIC,
                 ],
                 on_assign=self._on_assign,
             )

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -97,14 +97,6 @@ class Settings(BaseSettings):
             return v
         return f"{values.get('PORT_ORG_ID')}.change.log"
 
-    KAFKA_WF_NODE_RUNS_TOPIC: str = ""
-
-    @validator("KAFKA_WF_NODE_RUNS_TOPIC", always=True)
-    def set_kafka_wf_node_runs_topic(cls, v: Optional[str], values: dict) -> str:
-        if isinstance(v, str) and v:
-            return v
-        return f"{values.get('PORT_ORG_ID')}.workflow.runs"
-
     class Config:
         case_sensitive = True
         env_file = find_dotenv()

--- a/app/core/consts.py
+++ b/app/core/consts.py
@@ -4,6 +4,8 @@ class Consts:
     MISSING_VALUE = "MISSING"
     VALID_STREAMER_TYPES = ["KAFKA", "POLLING"]
     PORT_EXEC_AGENT_CLAIMING_KEY = "_PORT_EXEC_AGENT"
+    ACTION_RUN_ID_PREFIX = "r_"
+    WF_NODE_RUN_ID_PREFIX = "wfnr_"
 
 
 consts = Consts()

--- a/app/invokers/webhook_invoker.py
+++ b/app/invokers/webhook_invoker.py
@@ -9,7 +9,13 @@ from core.config import Mapping, control_the_payload_config, settings
 from core.consts import consts
 from flatten_dict import flatten, unflatten
 from invokers.base_invoker import BaseInvoker
-from port_client import report_run_response, report_run_status, run_logger_factory
+from port_client import (
+    report_run_response,
+    report_run_status,
+    report_wf_node_run_status,
+    run_logger_factory,
+    wf_node_run_logger_factory,
+)
 from pydantic import BaseModel, Field
 from requests import Response
 from utils import (
@@ -269,6 +275,39 @@ class WebhookInvoker(BaseInvoker):
 
         return res
 
+    @staticmethod
+    def _report_wf_node_run_failure(run_id: str) -> None:
+        try:
+            report_wf_node_run_status(run_id, {"status": "COMPLETED", "result": "FAILED"})
+        except Exception:
+            logger.error(
+                "Failed to report FAILED status for workflow node run %s",
+                run_id,
+                exc_info=True,
+            )
+
+    def _invoke_wf_node_run(
+        self, run_id: str, mapping: Mapping, msg: dict, invocation_method: dict
+    ) -> None:
+        node_run_logger = wf_node_run_logger_factory(run_id)
+        node_run_logger("A workflow node run has been received")
+        request_payload = self._prepare_payload(mapping, msg, invocation_method)
+        node_run_logger("Preparing the payload for the request")
+        try:
+            res = self._request(request_payload, node_run_logger)
+            res.raise_for_status()
+        except Exception:
+            logger.error(
+                "Webhook failed for workflow node run %s",
+                run_id,
+                exc_info=True,
+            )
+            self._report_wf_node_run_failure(run_id)
+            raise
+        output = {"response": {"status": res.status_code, "data": get_response_body(res) or {}}}
+        report_wf_node_run_status(run_id, {"status": "COMPLETED", "result": "SUCCESS", "output": output})
+        node_run_logger("Port agent finished processing the workflow node run")
+
     def _invoke_run(
         self, run_id: str, mapping: Mapping, body: dict, invocation_method: dict
     ) -> None:
@@ -352,7 +391,7 @@ class WebhookInvoker(BaseInvoker):
         msg: dict,
         invocation_method: dict,
         skip_signature_validation: bool = False,
-    ) -> None:
+    ) -> bool:
         log_by_detail_level(
             logger.info,
             "WebhookInvoker - start - destination type: %s",
@@ -360,13 +399,16 @@ class WebhookInvoker(BaseInvoker):
             "details",
             invocation_method,
         )
-        run_id = msg["context"].get("runId")
+        run_id = msg.get("context", {}).get("runId")
+        is_wf_node_run = bool(run_id and run_id.startswith(consts.WF_NODE_RUN_ID_PREFIX))
 
         invocation_method_name = invocation_method.get("type") or consts.MISSING_VALUE
         if not skip_signature_validation and not self.validate_incoming_signature(
             msg, invocation_method_name
         ):
-            return
+            if is_wf_node_run:
+                self._report_wf_node_run_failure(run_id)
+            return False
 
         logger.info("WebhookInvoker - validating signature")
 
@@ -382,13 +424,16 @@ class WebhookInvoker(BaseInvoker):
                 "msg",
                 msg,
             )
-            return
+            if is_wf_node_run:
+                self._report_wf_node_run_failure(run_id)
+            return False
 
         self._replace_encrypted_fields(msg, mapping)
 
-        if run_id:
+        if is_wf_node_run:
+            self._invoke_wf_node_run(run_id, mapping, msg, invocation_method)
+        elif run_id:
             self._invoke_run(run_id, mapping, msg, invocation_method)
-        # Used for changelog destination event trigger
         elif invocation_method.get("url"):
             request_payload = self._prepare_payload(mapping, msg, invocation_method)
             res = self._request(request_payload, lambda _: None)
@@ -398,7 +443,9 @@ class WebhookInvoker(BaseInvoker):
                 "WebhookInvoker - Could not find suitable "
                 "invocation method for the event"
             )
+            return False
         logger.info("Finished processing the event")
+        return True
 
     def _replace_encrypted_fields(self, msg: dict, mapping: Mapping) -> None:
         fields_to_decrypt = getattr(mapping, "fieldsToDecryptPaths", None)

--- a/app/invokers/webhook_invoker.py
+++ b/app/invokers/webhook_invoker.py
@@ -278,7 +278,9 @@ class WebhookInvoker(BaseInvoker):
     @staticmethod
     def _report_wf_node_run_failure(run_id: str) -> None:
         try:
-            report_wf_node_run_status(run_id, {"status": "COMPLETED", "result": "FAILED"})
+            report_wf_node_run_status(
+                run_id, {"status": "COMPLETED", "result": "FAILED"}
+            )
         except Exception:
             logger.error(
                 "Failed to report FAILED status for workflow node run %s",
@@ -304,8 +306,15 @@ class WebhookInvoker(BaseInvoker):
             )
             self._report_wf_node_run_failure(run_id)
             raise
-        output = {"response": {"status": res.status_code, "data": get_response_body(res) or {}}}
-        report_wf_node_run_status(run_id, {"status": "COMPLETED", "result": "SUCCESS", "output": output})
+        output = {
+            "response": {
+                "status": res.status_code,
+                "data": get_response_body(res) or {},
+            }
+        }
+        report_wf_node_run_status(
+            run_id, {"status": "COMPLETED", "result": "SUCCESS", "output": output}
+        )
         node_run_logger("Port agent finished processing the workflow node run")
 
     def _invoke_run(
@@ -400,7 +409,9 @@ class WebhookInvoker(BaseInvoker):
             invocation_method,
         )
         run_id = msg.get("context", {}).get("runId")
-        is_wf_node_run = bool(run_id and run_id.startswith(consts.WF_NODE_RUN_ID_PREFIX))
+        is_wf_node_run = bool(
+            run_id and run_id.startswith(consts.WF_NODE_RUN_ID_PREFIX)
+        )
 
         invocation_method_name = invocation_method.get("type") or consts.MISSING_VALUE
         if not skip_signature_validation and not self.validate_incoming_signature(

--- a/app/invokers/webhook_invoker.py
+++ b/app/invokers/webhook_invoker.py
@@ -294,7 +294,6 @@ class WebhookInvoker(BaseInvoker):
         node_run_logger = wf_node_run_logger_factory(run_id)
         node_run_logger("A workflow node run has been received")
         request_payload = self._prepare_payload(mapping, msg, invocation_method)
-        node_run_logger("Preparing the payload for the request")
         try:
             res = self._request(request_payload, node_run_logger)
             res.raise_for_status()

--- a/app/port_client.py
+++ b/app/port_client.py
@@ -50,6 +50,19 @@ def run_logger_factory(run_id: str) -> Callable[[str], None]:
     return send_run_log
 
 
+def wf_node_run_logger_factory(node_run_id: str) -> Callable[[str], None]:
+    def send_log(message: str) -> None:
+        headers = get_port_api_headers()
+
+        requests.post(
+            f"{settings.PORT_API_BASE_URL}/v1/workflows/nodes/runs/{node_run_id}/logs",
+            json={"logs": [{"level": "INFO", "message": message}]},
+            headers=headers,
+        )
+
+    return send_log
+
+
 def report_run_status(run_id: str, data_to_patch: dict) -> Response:
     headers = get_port_api_headers()
     res = requests.patch(

--- a/app/processors/kafka/kafka_to_webhook_processor.py
+++ b/app/processors/kafka/kafka_to_webhook_processor.py
@@ -29,4 +29,3 @@ class KafkaToWebhookProcessor:
                 msg.partition(),
                 msg.offset(),
             )
-

--- a/app/processors/kafka/kafka_to_webhook_processor.py
+++ b/app/processors/kafka/kafka_to_webhook_processor.py
@@ -4,7 +4,6 @@ import logging
 from confluent_kafka import Message
 from core.config import settings
 from invokers.webhook_invoker import webhook_invoker
-from port_client import report_wf_node_run_status
 from utils import log_by_detail_level
 
 logging.basicConfig(level=settings.LOG_LEVEL)
@@ -23,63 +22,11 @@ class KafkaToWebhookProcessor:
         )
         msg_value = json.loads(msg.value().decode())
 
-        if topic == settings.KAFKA_WF_NODE_RUNS_TOPIC:
-            KafkaToWebhookProcessor._process_wf_node_run(msg_value, invocation_method)
-            return
-
-        webhook_invoker.invoke(msg_value, invocation_method)
-        logger.info(
-            "Successfully processed message from topic %s, partition %d, offset %d",
-            topic,
-            msg.partition(),
-            msg.offset(),
-        )
-
-    @staticmethod
-    def _process_wf_node_run(node_run: dict, invocation_method: dict) -> None:
-        node_run_id = node_run.get("identifier")
-        if not node_run_id:
-            logger.error("Workflow node run missing identifier: %s", node_run)
-            return
-        logger.info("Processing workflow node run: %s", node_run_id)
-
-        config = node_run.get("config") or {}
-        msg_value = {
-            "headers": invocation_method.get("headers", {}),
-            "payload": {
-                "action": {"invocationMethod": invocation_method},
-            },
-            "context": {
-                "nodeRunIdentifier": node_run_id,
-                "nodeConfig": config,
-            },
-        }
-
-        try:
-            webhook_invoker.invoke(msg_value, invocation_method)
-            report_wf_node_run_status(
-                node_run_id,
-                {"status": "COMPLETED", "result": "SUCCESS"},
-            )
+        if webhook_invoker.invoke(msg_value, invocation_method):
             logger.info(
-                "Successfully processed workflow node run %s",
-                node_run_id,
+                "Successfully processed message from topic %s, partition %d, offset %d",
+                topic,
+                msg.partition(),
+                msg.offset(),
             )
-        except Exception:
-            logger.error(
-                "Webhook failed for workflow node run %s",
-                node_run_id,
-                exc_info=True,
-            )
-            try:
-                report_wf_node_run_status(
-                    node_run_id,
-                    {"status": "COMPLETED", "result": "FAILURE"},
-                )
-            except Exception:
-                logger.error(
-                    "Failed to report failure status for workflow node run %s",
-                    node_run_id,
-                    exc_info=True,
-                )
-            raise
+

--- a/app/processors/polling/polling_to_webhook_processor.py
+++ b/app/processors/polling/polling_to_webhook_processor.py
@@ -57,5 +57,7 @@ class PollingToWebhookProcessor:
             },
         }
 
-        if webhook_invoker.invoke(msg_value, invocation_method, skip_signature_validation=True):
+        if webhook_invoker.invoke(
+            msg_value, invocation_method, skip_signature_validation=True
+        ):
             logger.info("Successfully processed workflow node run %s", node_run_id)

--- a/app/processors/polling/polling_to_webhook_processor.py
+++ b/app/processors/polling/polling_to_webhook_processor.py
@@ -2,7 +2,6 @@ import logging
 
 from core.config import settings
 from invokers.webhook_invoker import webhook_invoker
-from port_client import report_wf_node_run_status
 
 logging.basicConfig(level=settings.LOG_LEVEL)
 logger = logging.getLogger(__name__)
@@ -53,40 +52,10 @@ class PollingToWebhookProcessor:
                 "action": {"invocationMethod": invocation_method},
             },
             "context": {
-                "nodeRunIdentifier": node_run_id,
+                "runId": node_run_id,
                 "nodeConfig": config,
             },
         }
 
-        try:
-            webhook_invoker.invoke(
-                msg_value,
-                invocation_method,
-                skip_signature_validation=True,
-            )
-            report_wf_node_run_status(
-                node_run_id,
-                {"status": "COMPLETED", "result": "SUCCESS"},
-            )
-            logger.info(
-                "Successfully processed workflow node run %s",
-                node_run_id,
-            )
-        except Exception:
-            logger.error(
-                "Webhook failed for workflow node run %s",
-                node_run_id,
-                exc_info=True,
-            )
-            try:
-                report_wf_node_run_status(
-                    node_run_id,
-                    {"status": "COMPLETED", "result": "FAILURE"},
-                )
-            except Exception:
-                logger.error(
-                    "Failed to report failure status for workflow node run %s",
-                    node_run_id,
-                    exc_info=True,
-                )
-            raise
+        if webhook_invoker.invoke(msg_value, invocation_method, skip_signature_validation=True):
+            logger.info("Successfully processed workflow node run %s", node_run_id)

--- a/app/streamers/kafka/kafka_streamer.py
+++ b/app/streamers/kafka/kafka_streamer.py
@@ -52,9 +52,6 @@ class KafkaStreamer(BaseStreamer):
         if topic == settings.KAFKA_CHANGE_LOG_TOPIC:
             return msg_value.get("changelogDestination", {})
 
-        if topic == settings.KAFKA_WF_NODE_RUNS_TOPIC:
-            return msg_value.get("config", {})
-
         return {}
 
     def stream(self) -> None:

--- a/tests/unit/processors/kafka/test_kafka_to_webhook_processor.py
+++ b/tests/unit/processors/kafka/test_kafka_to_webhook_processor.py
@@ -17,29 +17,6 @@ from app.utils import sign_sha_256
 from tests.unit.processors.kafka.conftest import Consumer, terminate_consumer
 
 
-def _attach_wf_node_port_signature(node_run: dict, timestamp: int = 1713277889) -> None:
-    invocation_method = node_run["config"]
-    node_run_id = node_run["identifier"]
-    config = node_run.get("config") or {}
-    headers = invocation_method.setdefault("headers", {})
-    headers.pop("X-Port-Signature", None)
-    headers.pop("X-Port-Timestamp", None)
-    wire_msg = {
-        "headers": headers,
-        "payload": {"action": {"invocationMethod": invocation_method}},
-        "context": {
-            "nodeRunIdentifier": node_run_id,
-            "nodeConfig": config,
-        },
-    }
-    headers["X-Port-Signature"] = sign_sha_256(
-        json.dumps(wire_msg, separators=(",", ":"), ensure_ascii=False),
-        settings.PORT_CLIENT_SECRET,
-        str(timestamp),
-    )
-    headers["X-Port-Timestamp"] = timestamp
-
-
 def _patch_requests_patch_ok(mocker: MockFixture) -> None:
     mock_resp = mock.MagicMock()
     mock_resp.status_code = 200
@@ -52,25 +29,32 @@ def _patch_requests_patch_ok(mocker: MockFixture) -> None:
 
 @pytest.fixture(scope="module")
 def mock_wf_node_run_message() -> Callable[[dict | None], bytes]:
+    invocation_method: dict = {
+        "type": "WEBHOOK",
+        "url": "https://httpbin.org/post",
+        "method": "POST",
+        "agent": True,
+        "headers": {"Content-Type": "application/json"},
+    }
     node_run_message: dict = {
-        "identifier": "wfnr_abc123",
-        "status": "IN_PROGRESS",
-        "config": {
-            "type": "WEBHOOK",
-            "url": "https://httpbin.org/post",
-            "method": "POST",
-            "agent": True,
-            "headers": {"Content-Type": "application/json"},
-        },
-        "pendingExecution": True,
+        "headers": {},
+        "payload": {"action": {"invocationMethod": invocation_method}},
+        "context": {"runId": "wfnr_abc123"},
     }
 
-    def get_node_run_message(config_override: dict | None) -> bytes:
+    def get_node_run_message(invocation_method_override: dict | None) -> bytes:
         msg = deepcopy(node_run_message)
-        if config_override is not None:
-            msg["config"] = config_override
-        if msg["config"].get("agent", True):
-            _attach_wf_node_port_signature(msg)
+        if invocation_method_override is not None:
+            msg["payload"]["action"]["invocationMethod"] = invocation_method_override
+        timestamp = 1713277889
+        msg["headers"] = {
+            "X-Port-Signature": sign_sha_256(
+                json.dumps(msg, separators=(",", ":")),
+                "test",
+                str(timestamp),
+            ),
+            "X-Port-Timestamp": timestamp,
+        }
         return json.dumps(msg).encode()
 
     return get_node_run_message
@@ -337,7 +321,7 @@ def test_invocation_method_method_override(
 @pytest.mark.parametrize(
     "mock_kafka",
     [
-        ("mock_wf_node_run_message", None, settings.KAFKA_WF_NODE_RUNS_TOPIC),
+        ("mock_wf_node_run_message", None, settings.KAFKA_RUNS_TOPIC),
     ],
     indirect=True,
 )
@@ -347,8 +331,14 @@ def test_wf_node_run_stream_success(
     mock_kafka: dict,
     mock_timestamp: None,
     mocker: MockFixture,
+    mock_control_the_payload_config: list[Mapping],
 ) -> None:
-    _patch_requests_patch_ok(mocker)
+    request_patch_mock = mocker.patch("requests.patch")
+    request_patch_mock.return_value.status_code = 200
+    request_patch_mock.return_value.ok = True
+    request_patch_mock.return_value.text = ""
+    request_patch_mock.return_value.json.return_value = {}
+    request_patch_mock.return_value.raise_for_status = mock.Mock()
     Timer(0.01, terminate_consumer).start()
 
     with mock.patch.object(consumer_logger, "error") as mock_error:
@@ -356,3 +346,12 @@ def test_wf_node_run_stream_success(
         streamer.stream()
 
         mock_error.assert_not_called()
+        request_patch_mock.assert_called_with(
+            f"{settings.PORT_API_BASE_URL}/v1/workflows/nodes/runs/wfnr_abc123",
+            json={
+                "status": "COMPLETED",
+                "result": "SUCCESS",
+                "output": {"response": {"status": 200, "data": {}}},
+            },
+            headers=ANY,
+        )

--- a/tests/unit/processors/polling/test_polling_to_webhook_processor.py
+++ b/tests/unit/processors/polling/test_polling_to_webhook_processor.py
@@ -3,6 +3,8 @@ from unittest.mock import patch
 import pytest
 from processors.polling.polling_to_webhook_processor import PollingToWebhookProcessor
 
+_INVOKER = "processors.polling.polling_to_webhook_processor.webhook_invoker"
+
 
 @pytest.fixture
 def sample_run():
@@ -136,7 +138,7 @@ def test_process_run_adds_run_id_to_context(mock_invoker):
 
 
 @patch("processors.polling.polling_to_webhook_processor.webhook_invoker")
-def test_process_run_preserves_existing_run_id(mock_invoker):
+def test_process_run_overwrites_body_run_id(mock_invoker):
     run = {
         "_id": "run_888",
         "id": "run_888",
@@ -168,11 +170,12 @@ def test_process_run_preserves_existing_run_id(mock_invoker):
 # --- Workflow node run processor tests ---
 
 
-@patch("processors.polling.polling_to_webhook_processor" ".report_wf_node_run_status")
-@patch("processors.polling.polling_to_webhook_processor.webhook_invoker")
+@patch(_INVOKER)
 def test_process_wf_node_run_success(
-    mock_invoker, mock_report, sample_wf_node_run, webhook_invocation_method
+    mock_invoker, sample_wf_node_run, webhook_invocation_method
 ):
+    mock_invoker.invoke.return_value = True
+
     processor = PollingToWebhookProcessor()
     processor.process_wf_node_run(sample_wf_node_run, webhook_invocation_method)
 
@@ -180,22 +183,16 @@ def test_process_wf_node_run_success(
     call_args = mock_invoker.invoke.call_args
     msg_value = call_args[0][0]
 
-    assert msg_value["context"]["nodeRunIdentifier"] == "wfnr_abc123"
+    assert msg_value["context"]["runId"] == "wfnr_abc123"
     assert msg_value["context"]["nodeConfig"]["type"] == "WEBHOOK"
     assert msg_value["payload"]["action"]["invocationMethod"] == (
         webhook_invocation_method
     )
 
-    mock_report.assert_called_once_with(
-        "wfnr_abc123",
-        {"status": "COMPLETED", "result": "SUCCESS"},
-    )
 
-
-@patch("processors.polling.polling_to_webhook_processor" ".report_wf_node_run_status")
-@patch("processors.polling.polling_to_webhook_processor.webhook_invoker")
-def test_process_wf_node_run_webhook_failure_reports_failure(
-    mock_invoker, mock_report, sample_wf_node_run, webhook_invocation_method
+@patch(_INVOKER)
+def test_process_wf_node_run_webhook_failure_propagates(
+    mock_invoker, sample_wf_node_run, webhook_invocation_method
 ):
     mock_invoker.invoke.side_effect = Exception("Connection refused")
 
@@ -203,15 +200,9 @@ def test_process_wf_node_run_webhook_failure_reports_failure(
     with pytest.raises(Exception, match="Connection refused"):
         processor.process_wf_node_run(sample_wf_node_run, webhook_invocation_method)
 
-    mock_report.assert_called_once_with(
-        "wfnr_abc123",
-        {"status": "COMPLETED", "result": "FAILURE"},
-    )
 
-
-@patch("processors.polling.polling_to_webhook_processor" ".report_wf_node_run_status")
-@patch("processors.polling.polling_to_webhook_processor.webhook_invoker")
-def test_process_wf_node_run_missing_identifier(mock_invoker, mock_report):
+@patch(_INVOKER)
+def test_process_wf_node_run_missing_identifier(mock_invoker):
     processor = PollingToWebhookProcessor()
     processor.process_wf_node_run(
         {"status": "IN_PROGRESS"},
@@ -219,12 +210,12 @@ def test_process_wf_node_run_missing_identifier(mock_invoker, mock_report):
     )
 
     mock_invoker.invoke.assert_not_called()
-    mock_report.assert_not_called()
 
 
-@patch("processors.polling.polling_to_webhook_processor" ".report_wf_node_run_status")
-@patch("processors.polling.polling_to_webhook_processor.webhook_invoker")
-def test_process_wf_node_run_empty_config(mock_invoker, mock_report):
+@patch(_INVOKER)
+def test_process_wf_node_run_empty_config(mock_invoker):
+    mock_invoker.invoke.return_value = True
+
     node_run = {
         "identifier": "wfnr_empty_config",
         "status": "IN_PROGRESS",
@@ -245,8 +236,3 @@ def test_process_wf_node_run_empty_config(mock_invoker, mock_report):
     call_args = mock_invoker.invoke.call_args
     msg_value = call_args[0][0]
     assert msg_value["context"]["nodeConfig"] == {}
-
-    mock_report.assert_called_once_with(
-        "wfnr_empty_config",
-        {"status": "COMPLETED", "result": "SUCCESS"},
-    )

--- a/tests/unit/streamers/kafka/test_kafka_streamer.py
+++ b/tests/unit/streamers/kafka/test_kafka_streamer.py
@@ -16,29 +16,6 @@ from app.utils import sign_sha_256
 from tests.unit.streamers.kafka.conftest import Consumer, terminate_consumer
 
 
-def _attach_wf_node_port_signature(node_run: dict, timestamp: int = 1713277889) -> None:
-    invocation_method = node_run["config"]
-    node_run_id = node_run["identifier"]
-    config = node_run.get("config") or {}
-    headers = invocation_method.setdefault("headers", {})
-    headers.pop("X-Port-Signature", None)
-    headers.pop("X-Port-Timestamp", None)
-    wire_msg = {
-        "headers": headers,
-        "payload": {"action": {"invocationMethod": invocation_method}},
-        "context": {
-            "nodeRunIdentifier": node_run_id,
-            "nodeConfig": config,
-        },
-    }
-    headers["X-Port-Signature"] = sign_sha_256(
-        json.dumps(wire_msg, separators=(",", ":"), ensure_ascii=False),
-        settings.PORT_CLIENT_SECRET,
-        str(timestamp),
-    )
-    headers["X-Port-Timestamp"] = timestamp
-
-
 def _patch_requests_patch_ok(mocker: MockFixture) -> None:
     mock_resp = mock.MagicMock()
     mock_resp.status_code = 200
@@ -51,25 +28,32 @@ def _patch_requests_patch_ok(mocker: MockFixture) -> None:
 
 @pytest.fixture(scope="module")
 def mock_wf_node_run_message() -> Callable[[dict | None], bytes]:
+    invocation_method: dict = {
+        "type": "WEBHOOK",
+        "url": "https://httpbin.org/post",
+        "method": "POST",
+        "agent": True,
+        "headers": {"Content-Type": "application/json"},
+    }
     node_run_message: dict = {
-        "identifier": "wfnr_abc123",
-        "status": "IN_PROGRESS",
-        "config": {
-            "type": "WEBHOOK",
-            "url": "https://httpbin.org/post",
-            "method": "POST",
-            "agent": True,
-            "headers": {"Content-Type": "application/json"},
-        },
-        "pendingExecution": True,
+        "headers": {},
+        "payload": {"action": {"invocationMethod": invocation_method}},
+        "context": {"runId": "wfnr_abc123"},
     }
 
-    def get_node_run_message(config_override: dict | None) -> bytes:
+    def get_node_run_message(invocation_method_override: dict | None) -> bytes:
         msg = deepcopy(node_run_message)
-        if config_override is not None:
-            msg["config"] = config_override
-        if msg["config"].get("agent", True):
-            _attach_wf_node_port_signature(msg)
+        if invocation_method_override is not None:
+            msg["payload"]["action"]["invocationMethod"] = invocation_method_override
+        timestamp = 1713277889
+        msg["headers"] = {
+            "X-Port-Signature": sign_sha_256(
+                json.dumps(msg, separators=(",", ":")),
+                "test",
+                str(timestamp),
+            ),
+            "X-Port-Timestamp": timestamp,
+        }
         return json.dumps(msg).encode()
 
     return get_node_run_message
@@ -170,7 +154,7 @@ def test_single_stream_skipped_due_to_agentless(
 @pytest.mark.parametrize(
     "mock_kafka",
     [
-        ("mock_wf_node_run_message", None, settings.KAFKA_WF_NODE_RUNS_TOPIC),
+        ("mock_wf_node_run_message", None, settings.KAFKA_RUNS_TOPIC),
     ],
     indirect=True,
 )
@@ -197,7 +181,7 @@ def test_wf_node_run_stream_success(
         (
             "mock_wf_node_run_message",
             {"type": "WEBHOOK", "url": "https://httpbin.org/post", "agent": False},
-            settings.KAFKA_WF_NODE_RUNS_TOPIC,
+            settings.KAFKA_RUNS_TOPIC,
         ),
     ],
     indirect=True,

--- a/tests/unit/streamers/polling/test_http_polling_consumer.py
+++ b/tests/unit/streamers/polling/test_http_polling_consumer.py
@@ -277,10 +277,7 @@ def test_http_polling_consumer_workflow_processing_error(
     mock_ack_wf_node_run.assert_called_with("wfnr_abc123")
     mock_report_wf_node_run_status.assert_called_with(
         "wfnr_abc123",
-        {
-            "status": "COMPLETED",
-            "result": "FAILURE",
-        },
+        {"status": "COMPLETED", "result": "FAILED"},
     )
 
 


### PR DESCRIPTION
# Description

What - Route workflow node runs through the standard KAFKA_RUNS_TOPIC
Why - The previous approach consumed a separate KAFKA_WF_NODE_RUNS_TOPIC which is redundant.
How - Remove KAFKA_WF_NODE_RUNS_TOPIC subscription and special-case processor logic.
 
## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

