### PR TITLE
feat: log Port agent version on startup

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -70,3 +70,4 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             AWS_ACCOUNT_ID=${{ secrets.AWS_ACCOUNT_ID }}
+            VERSION=${{ github.ref_type == 'tag' && github.ref_name || 'dev' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,10 @@ ARG BASE_PYTHON_IMAGE=${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-1.amazonaws.com/echo/pyt
 FROM ${BASE_PYTHON_IMAGE} AS prod
 
 ARG AGENT_USER_ID=1000
+ARG VERSION=unknown
 
 ENV LIBRDKAFKA_VERSION=1.9.2
+ENV PORT_AGENT_VERSION=${VERSION}
 
 # Create a dedicated user and group
 RUN groupadd --gid ${AGENT_USER_ID} appgroup && \

--- a/app/core/version.py
+++ b/app/core/version.py
@@ -1,0 +1,16 @@
+import os
+from importlib.metadata import PackageNotFoundError, version
+
+PORT_AGENT_PACKAGE_NAME = "port-agent"
+PORT_AGENT_VERSION_ENV = "PORT_AGENT_VERSION"
+
+
+def get_version() -> str:
+    env_version = os.getenv(PORT_AGENT_VERSION_ENV)
+    if env_version:
+        return env_version
+
+    try:
+        return version(PORT_AGENT_PACKAGE_NAME)
+    except PackageNotFoundError:
+        return "unknown"

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,7 @@
 import logging
 
 from core.config import settings
+from core.version import get_version
 from port_client import patch_org_streamer_setting
 from streamers.streamer_factory import StreamerFactory
 
@@ -9,6 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 def main() -> None:
+    logger.info("Starting Port Execution Agent version %s", get_version())
     try:
         logger.info(
             "Updating org streamer setting to match streamer type: %s",


### PR DESCRIPTION
## Summary
- Add `app/core/version.py` to resolve version from `PORT_AGENT_VERSION` or package metadata
- Log agent version at startup in `main.py`
- Pass build version into the Docker image via CI and `Dockerfile`

## Test plan
- [x] Build image and confirm `PORT_AGENT_VERSION` is set
- [x] Start agent and verify version appears in startup logs


Made with [Cursor](https://cursor.com)