### PR TITLE
fix(workflows): make unmatched-mapping failure on workflow node runs opt-out

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -105,6 +105,15 @@ class Settings(BaseSettings):
     WEBHOOK_INVOKER_TIMEOUT: float = 30
     WEBHOOK_VERIFY_SSL: bool = True
 
+    # When multiple execution agents share one org's Kafka topic (e.g. one agent
+    # per cluster, each with its own controlThePayloadConfig filter, as described in
+    # https://docs.port.io/workflows/actions-and-automations/setup-backend/webhook/port-execution-agent/control-the-payload/#mapping-examples),
+    # every agent receives every workflow node run event, and an unmatched mapping on
+    # a given agent simply means "not my cluster" rather than a real misconfiguration.
+    # Set to False in that setup so an unmatched mapping is skipped silently instead
+    # of failing the run out from under whichever agent *does* own it.
+    FAIL_WORKFLOW_NODE_RUN_ON_UNMATCHED_MAPPING: bool = True
+
 
 settings = Settings()
 

--- a/app/invokers/webhook_invoker.py
+++ b/app/invokers/webhook_invoker.py
@@ -436,7 +436,7 @@ class WebhookInvoker(BaseInvoker):
                 "msg",
                 msg,
             )
-            if is_wf_node_run:
+            if is_wf_node_run and settings.FAIL_WORKFLOW_NODE_RUN_ON_UNMATCHED_MAPPING:
                 self._report_wf_node_run_failure(run_id)
             return False
 

--- a/tests/unit/invokers/test_webhook_invoker.py
+++ b/tests/unit/invokers/test_webhook_invoker.py
@@ -6,8 +6,49 @@ from glom import assign, glom
 from glom.core import PathAssignError
 from invokers.webhook_invoker import WebhookInvoker
 
-from app.core.config import Mapping
+from app.core.config import Mapping, settings
 from app.utils import decrypt_field, decrypt_payload_fields
+
+
+def _wf_node_run_message() -> Dict[str, Any]:
+    return {
+        "context": {"runId": "wfnr_doesNotMatchAnyMapping"},
+        "headers": {
+            "X-Port-Signature": "sig",
+            "X-Port-Timestamp": "123",
+        },
+    }
+
+
+@mock.patch("invokers.webhook_invoker.control_the_payload_config", [])
+@mock.patch("invokers.webhook_invoker.report_wf_node_run_status")
+@mock.patch.object(WebhookInvoker, "validate_incoming_signature", return_value=True)
+def test_unmatched_mapping_fails_wf_node_run_by_default(
+    _mock_validate: object, mock_report: mock.Mock
+) -> None:
+    invoker = WebhookInvoker()
+    result = invoker.invoke(_wf_node_run_message(), invocation_method={})
+    assert result is False
+    mock_report.assert_called_once_with(
+        "wfnr_doesNotMatchAnyMapping", {"status": "COMPLETED", "result": "FAILED"}
+    )
+
+
+@mock.patch("invokers.webhook_invoker.control_the_payload_config", [])
+@mock.patch("invokers.webhook_invoker.report_wf_node_run_status")
+@mock.patch.object(WebhookInvoker, "validate_incoming_signature", return_value=True)
+def test_unmatched_mapping_skips_silently_when_disabled(
+    _mock_validate: object, mock_report: mock.Mock
+) -> None:
+    original = settings.FAIL_WORKFLOW_NODE_RUN_ON_UNMATCHED_MAPPING
+    settings.FAIL_WORKFLOW_NODE_RUN_ON_UNMATCHED_MAPPING = False
+    try:
+        invoker = WebhookInvoker()
+        result = invoker.invoke(_wf_node_run_message(), invocation_method={})
+    finally:
+        settings.FAIL_WORKFLOW_NODE_RUN_ON_UNMATCHED_MAPPING = original
+    assert result is False
+    mock_report.assert_not_called()
 
 
 def inplace_decrypt_mock(


### PR DESCRIPTION
## Problem

We run two execution agents against the same org's Kafka topic — one per Kubernetes cluster (prod + staging), each with its own `controlThePayloadConfig` filter matching only its own cluster's URLs, following the documented [multi-cluster pattern](https://docs.port.io/workflows/actions-and-automations/setup-backend/webhook/port-execution-agent/control-the-payload/#mapping-examples):

> If you have multiple clusters without network connectivity between them, you can deploy a separate port-agent on each cluster. All agents consume from the same Kafka topic, but each agent uses a different `enabled` filter to process only the actions relevant to its cluster.

Since both agents consume every message from the shared topic, a workflow node run whose URL only matches *one* agent's mapping is still delivered to the other agent too. On that other agent, `_find_mapping` correctly returns `None` (it's not the intended handler) — but for workflow node runs specifically, `invoke()` treats that as a failure:

```python
mapping = self._find_mapping(msg)
if mapping is None:
    ...
    if is_wf_node_run:
        self._report_wf_node_run_failure(run_id)   # PATCHes {"status":"COMPLETED","result":"FAILED"}
    return False
```

This reports the run as `FAILED` (empty output) from the agent that was never supposed to act on it. Since that report needs no network I/O, it lands almost instantly — racing ahead of the correct agent, which still has to make the real webhook call. In practice this means the node is closed out `FAILED` within ~1-2 seconds of dispatch, before the correct agent's request (or the backend's own eventual status callback) ever has a chance to land. We reproduced this 100% of the time for an `agent: true, synchronized: false` workflow node whose URL only matched one of our two agents' mappings.

This directly undermines the documented multi-agent pattern above: for regular action runs, an unmatched mapping is a silent no-op (`elif run_id: ...` / plain `return` path). Workflow node runs are the only case where a mapping miss becomes an active failure report.

We bisected this against the `port-agent` tags: this behavior (the whole `is_wf_node_run` branch, added in "Improve Workflow node runs handling") was introduced between v0.8.7 and v0.8.8, and is still present on `main`. There's no earlier tag that has synchronized workflow-node-run support without this failure-report behavior.

## Fix

Added `FAIL_WORKFLOW_NODE_RUN_ON_UNMATCHED_MAPPING` (default `True`, so existing single-agent deployments keep today's behavior unchanged) that gates just this one call site. Setting it to `False` restores the same silent-skip behavior workflow node runs already get for every other failure-adjacent branch that isn't this one (e.g. this doesn't touch the signature-validation-failure path, which is a genuine integrity failure and should stay as-is).

Also added two unit tests covering both settings values for an unmatched mapping on a workflow node run.

Happy to adjust the approach (e.g. a different name/default, or scoping this differently) if you'd prefer — just wanted to get a working fix up given how disruptive this is for any multi-agent deployment.