### PR TITLE
fix(polling): preserve invocation method body

### DIFF
--- a/app/invokers/webhook_invoker.py
+++ b/app/invokers/webhook_invoker.py
@@ -436,8 +436,6 @@ class WebhookInvoker(BaseInvoker):
                 "msg",
                 msg,
             )
-            if is_wf_node_run:
-                self._report_wf_node_run_failure(run_id)
             return False
 
         self._replace_encrypted_fields(msg, mapping)

--- a/app/processors/polling/polling_to_webhook_processor.py
+++ b/app/processors/polling/polling_to_webhook_processor.py
@@ -1,4 +1,5 @@
 import logging
+from copy import deepcopy
 
 from core.config import settings
 from invokers.webhook_invoker import webhook_invoker
@@ -17,14 +18,17 @@ class PollingToWebhookProcessor:
         logger.info("Processing action run: %s", run_id)
 
         payload = run["payload"]
-        msg_value = payload["body"].copy()
+        msg_value = deepcopy(payload["body"])
 
-        msg_value["headers"] = invocation_method.get("headers", {})
+        msg_value.setdefault("headers", {})
+        if headers := invocation_method.get("headers"):
+            msg_value["headers"] = headers
 
         if "payload" not in msg_value:
             msg_value["payload"] = {}
         if "action" not in msg_value["payload"]:
             msg_value["payload"]["action"] = {}
+
         msg_value["payload"]["action"]["invocationMethod"] = invocation_method
 
         if "context" not in msg_value:
@@ -41,21 +45,18 @@ class PollingToWebhookProcessor:
     def process_wf_node_run(node_run: dict, invocation_method: dict) -> None:
         node_run_id = node_run.get("identifier")
         if not node_run_id:
-            logger.error(
-                "Workflow node run missing identifier: %s", node_run
-            )
+            logger.error("Workflow node run missing identifier: %s", node_run)
             return
         logger.info("Processing workflow node run: %s", node_run_id)
 
-        config = node_run.get("config") or {}
         msg_value = {
-            "headers": invocation_method.get("headers", {}),
+            **deepcopy(invocation_method.get("body") or {}),
+            "headers": invocation_method.get("headers") or {},
             "payload": {
                 "action": {"invocationMethod": invocation_method},
             },
             "context": {
                 "runId": node_run_id,
-                "nodeConfig": config,
             },
         }
 

--- a/app/streamers/polling/polling_streamer.py
+++ b/app/streamers/polling/polling_streamer.py
@@ -4,9 +4,34 @@ from consumers.http_polling_consumer import HttpPollingConsumer
 from core.config import settings
 from processors.polling.polling_to_webhook_processor import PollingToWebhookProcessor
 from streamers.base_streamer import BaseStreamer
+from utils import get_invocation_method_object
 
 logging.basicConfig(level=settings.LOG_LEVEL)
 logger = logging.getLogger(__name__)
+
+# The polling API sends the invocation method flattened on the run payload, while
+# the event kept in payload.body carries the complete object. Only keys actually
+# present in the flattened payload may override the ones from the event.
+FLATTENED_INVOCATION_METHOD_KEYS = (
+    "type",
+    "url",
+    "agent",
+    "synchronized",
+    "method",
+    "headers",
+)
+PORT_EVENT_KEYS = ("context", "payload", "trigger")
+
+
+def _looks_like_port_event(body: dict) -> bool:
+    return any(key in body for key in PORT_EVENT_KEYS)
+
+
+def _with_defaults(invocation_method: dict) -> dict:
+    defaults = {"synchronized": False, "method": "POST", "headers": {}}
+    for key, default in defaults.items():
+        invocation_method.setdefault(key, default)
+    return invocation_method
 
 
 class PollingStreamer(BaseStreamer):
@@ -24,14 +49,27 @@ class PollingStreamer(BaseStreamer):
         logger.info("Processing run: %s", run_id)
 
         payload = run["payload"]
-        invocation_method = {
-            "type": payload["type"],
-            "url": payload["url"],
-            "agent": payload["agent"],
-            "synchronized": payload.get("synchronized", False),
-            "method": payload.get("method", "POST"),
-            "headers": payload.get("headers", {}),
-        }
+        body = payload.get("body") or {}
+        if not _looks_like_port_event(body):
+            logger.warning(
+                "Run %s: payload.body does not look like a Port event, keys: %s",
+                run_id,
+                sorted(body),
+            )
+
+        invocation_method = _with_defaults(
+            {
+                **get_invocation_method_object(body),
+                **{
+                    key: payload[key]
+                    for key in FLATTENED_INVOCATION_METHOD_KEYS
+                    if key in payload
+                },
+            }
+        )
+
+        if not invocation_method.get("type") or not invocation_method.get("url"):
+            raise ValueError(f"Run {run_id} has no invocation method type or url")
 
         if not invocation_method.pop("agent", False):
             logger.warning("Skip process run %s: not for agent", run_id)
@@ -42,21 +80,11 @@ class PollingStreamer(BaseStreamer):
     def process_wf_node_run(self, node_run: dict) -> None:
         node_run_id = node_run.get("identifier")
         if not node_run_id:
-            logger.error(
-                "Workflow node run missing identifier: %s", node_run
-            )
+            logger.error("Workflow node run missing identifier: %s", node_run)
             return
         logger.info("Processing workflow node run: %s", node_run_id)
 
-        config = node_run.get("config") or {}
-        invocation_method = {
-            "type": config.get("type"),
-            "url": config.get("url"),
-            "agent": config.get("agent"),
-            "synchronized": config.get("synchronized", False),
-            "method": config.get("method", "POST"),
-            "headers": config.get("headers", {}),
-        }
+        invocation_method = {**(node_run.get("config") or {})}
 
         if not invocation_method.pop("agent", False):
             logger.warning("Skip workflow node run %s: not for agent", node_run_id)

--- a/tests/unit/invokers/test_webhook_invoker.py
+++ b/tests/unit/invokers/test_webhook_invoker.py
@@ -10,6 +10,21 @@ from app.core.config import Mapping
 from app.utils import decrypt_field, decrypt_payload_fields
 
 
+def test_invoke_wf_node_run_skips_silently_when_no_mapping_matches() -> None:
+    invoker = WebhookInvoker()
+    msg = {"context": {"runId": "wfnr_abc123"}, "payload": {"cluster": "other"}}
+    invocation_method = {"type": "WEBHOOK", "agent": True}
+
+    with (
+        mock.patch.object(invoker, "_find_mapping", return_value=None),
+        mock.patch.object(invoker, "_report_wf_node_run_failure") as report_failure,
+    ):
+        result = invoker.invoke(msg, invocation_method, skip_signature_validation=True)
+
+    assert result is False
+    report_failure.assert_not_called()
+
+
 def inplace_decrypt_mock(
     payload: Dict[str, Any], fields: List[str], key: str
 ) -> Dict[str, Any]:

--- a/tests/unit/processors/kafka/conftest.py
+++ b/tests/unit/processors/kafka/conftest.py
@@ -40,6 +40,7 @@ def mock_requests(monkeypatch: MonkeyPatch, request: Any) -> None:
     monkeypatch.setattr(requests, "post", mock_request)
     monkeypatch.setattr(requests, "delete", mock_request)
     monkeypatch.setattr(requests, "put", mock_request)
+    monkeypatch.setattr(requests, "patch", mock_request)
 
 
 def terminate_consumer() -> None:

--- a/tests/unit/processors/polling/test_polling_to_webhook_processor.py
+++ b/tests/unit/processors/polling/test_polling_to_webhook_processor.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from typing import Any, Dict
 from unittest.mock import patch
 
@@ -109,6 +110,89 @@ def test_process_run_without_invocation_method(mock_invoker: Any) -> None:
 
 
 @patch("processors.polling.polling_to_webhook_processor.webhook_invoker")
+def test_process_run_forwards_the_invocation_method_as_is(mock_invoker: Any) -> None:
+    run = {
+        "id": "run_body",
+        "payload": {
+            "type": "WEBHOOK",
+            "url": "http://localhost:8080/webhook",
+            "agent": True,
+            "body": {
+                "context": {"entity": "entity_123"},
+                "payload": {
+                    "action": {
+                        "identifier": "deploy",
+                        "invocationMethod": {"url": "http://stale.example.com"},
+                    }
+                },
+            },
+        },
+    }
+    invocation_method = {
+        "type": "WEBHOOK",
+        "url": "http://localhost:8080/webhook",
+        "synchronized": True,
+        "method": "POST",
+        "headers": {},
+        "body": {"foo": "bar"},
+        "omitPayload": True,
+    }
+
+    PollingToWebhookProcessor().process_run(run, invocation_method)
+
+    msg_value, invocation_method_arg = mock_invoker.invoke.call_args[0]
+    assert msg_value["payload"]["action"]["invocationMethod"] == invocation_method
+    assert msg_value["payload"]["action"]["identifier"] == "deploy"
+    assert invocation_method_arg is invocation_method
+
+
+@patch("processors.polling.polling_to_webhook_processor.webhook_invoker")
+def test_process_run_does_not_mutate_the_run(mock_invoker: Any) -> None:
+    run = {
+        "id": "run_immutable",
+        "payload": {
+            "type": "WEBHOOK",
+            "url": "http://localhost:8080/webhook",
+            "agent": True,
+            "body": {
+                "context": {"runId": "existing_run_id"},
+                "payload": {"action": {"invocationMethod": {"body": {"foo": "bar"}}}},
+            },
+        },
+    }
+    original_run = deepcopy(run)
+
+    PollingToWebhookProcessor().process_run(
+        run, {"type": "WEBHOOK", "url": "http://localhost:8080/webhook"}
+    )
+
+    assert run == original_run
+
+
+@patch("processors.polling.polling_to_webhook_processor.webhook_invoker")
+def test_process_run_keeps_event_headers_when_invocation_method_has_none(
+    mock_invoker: Any,
+) -> None:
+    run = {
+        "id": "run_headers",
+        "payload": {
+            "type": "WEBHOOK",
+            "url": "http://localhost:8080/webhook",
+            "agent": True,
+            "body": {"context": {}, "headers": {"X-Existing": "1"}},
+        },
+    }
+
+    PollingToWebhookProcessor().process_run(
+        run,
+        {"type": "WEBHOOK", "url": "http://localhost:8080/webhook", "headers": {}},
+    )
+
+    msg_value = mock_invoker.invoke.call_args[0][0]
+    assert msg_value["headers"] == {"X-Existing": "1"}
+
+
+@patch("processors.polling.polling_to_webhook_processor.webhook_invoker")
 def test_process_run_adds_run_id_to_context(mock_invoker: Any) -> None:
     run = {
         "_id": "run_999",
@@ -191,6 +275,29 @@ def test_process_wf_node_run_success(
     assert msg_value["payload"]["action"]["invocationMethod"] == (
         webhook_invocation_method
     )
+
+
+@patch(_INVOKER)
+def test_process_wf_node_run_forwards_the_invocation_method_body(
+    mock_invoker: Any,
+    sample_wf_node_run: Dict[str, Any],
+) -> None:
+    mock_invoker.invoke.return_value = True
+    invocation_method = {
+        "type": "WEBHOOK",
+        "url": "https://httpbin.org/post",
+        "method": "POST",
+        "headers": {},
+        "body": {"service": "payments"},
+        "onTimeout": "continue",
+    }
+
+    PollingToWebhookProcessor().process_wf_node_run(
+        sample_wf_node_run, invocation_method
+    )
+
+    msg_value = mock_invoker.invoke.call_args[0][0]
+    assert msg_value["payload"]["action"]["invocationMethod"] == invocation_method
 
 
 @patch(_INVOKER)

--- a/tests/unit/streamers/kafka/conftest.py
+++ b/tests/unit/streamers/kafka/conftest.py
@@ -46,6 +46,7 @@ def mock_requests(monkeypatch: MonkeyPatch, request: Any) -> None:
     monkeypatch.setattr(requests, "post", mock_request)
     monkeypatch.setattr(requests, "delete", mock_request)
     monkeypatch.setattr(requests, "put", mock_request)
+    monkeypatch.setattr(requests, "patch", mock_request)
 
 
 def terminate_consumer() -> None:

--- a/tests/unit/streamers/polling/test_polling_streamer.py
+++ b/tests/unit/streamers/polling/test_polling_streamer.py
@@ -1,8 +1,22 @@
+import logging
 from threading import Timer
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
 from streamers.polling.polling_streamer import PollingStreamer
+
+
+def build_run(payload: dict) -> dict:
+    return {"_id": "run_nested", "id": "run_nested", "payload": payload}
+
+
+def event_with_invocation_method(invocation_method: dict) -> dict:
+    return {
+        "context": {"runId": "run_nested"},
+        "payload": {"action": {"invocationMethod": invocation_method}},
+        "trigger": {"by": {"userId": "user_123"}},
+    }
 
 
 def test_polling_streamer_initialization() -> None:
@@ -95,6 +109,144 @@ def test_polling_streamer_process_run_skips_non_agent(
         mock_processor.process_run.assert_not_called()
 
 
+@patch("streamers.polling.polling_streamer.PollingToWebhookProcessor")
+def test_polling_streamer_process_run_keeps_fields_only_in_the_event(
+    mock_processor_class: Any,
+) -> None:
+    mock_processor = MagicMock()
+    mock_processor_class.return_value = mock_processor
+
+    run = build_run(
+        {
+            "type": "WEBHOOK",
+            "url": "http://localhost:8080/webhook",
+            "agent": True,
+            "synchronized": False,
+            "method": "POST",
+            "headers": {},
+            "body": event_with_invocation_method(
+                {
+                    "type": "WEBHOOK",
+                    "url": "http://stale.example.com",
+                    "agent": True,
+                    "body": {"foo": "bar"},
+                    "omitPayload": True,
+                }
+            ),
+        }
+    )
+
+    with patch("streamers.polling.polling_streamer.HttpPollingConsumer"):
+        PollingStreamer().process_run(run)
+
+    invocation_method = mock_processor.process_run.call_args[0][1]
+    assert invocation_method["body"] == {"foo": "bar"}
+    assert invocation_method["omitPayload"] is True
+    assert invocation_method["url"] == "http://localhost:8080/webhook"
+    assert "agent" not in invocation_method
+
+
+@patch("streamers.polling.polling_streamer.PollingToWebhookProcessor")
+def test_polling_streamer_process_run_defaults_do_not_override_the_event(
+    mock_processor_class: Any,
+) -> None:
+    mock_processor = MagicMock()
+    mock_processor_class.return_value = mock_processor
+
+    run = build_run(
+        {
+            "type": "WEBHOOK",
+            "url": "http://localhost:8080/webhook",
+            "agent": True,
+            "body": event_with_invocation_method(
+                {
+                    "synchronized": True,
+                    "method": "PUT",
+                    "headers": {"X-Custom": "1"},
+                }
+            ),
+        }
+    )
+
+    with patch("streamers.polling.polling_streamer.HttpPollingConsumer"):
+        PollingStreamer().process_run(run)
+
+    invocation_method = mock_processor.process_run.call_args[0][1]
+    assert invocation_method["synchronized"] is True
+    assert invocation_method["method"] == "PUT"
+    assert invocation_method["headers"] == {"X-Custom": "1"}
+
+
+@patch("streamers.polling.polling_streamer.PollingToWebhookProcessor")
+def test_polling_streamer_process_run_honors_agent_from_the_event(
+    mock_processor_class: Any,
+) -> None:
+    mock_processor = MagicMock()
+    mock_processor_class.return_value = mock_processor
+
+    run = build_run(
+        {
+            "type": "WEBHOOK",
+            "url": "http://localhost:8080/webhook",
+            "body": event_with_invocation_method({"agent": True}),
+        }
+    )
+
+    with patch("streamers.polling.polling_streamer.HttpPollingConsumer"):
+        PollingStreamer().process_run(run)
+
+    mock_processor.process_run.assert_called_once()
+    assert "agent" not in mock_processor.process_run.call_args[0][1]
+
+
+@patch("streamers.polling.polling_streamer.PollingToWebhookProcessor")
+def test_polling_streamer_process_run_warns_when_body_is_not_a_port_event(
+    mock_processor_class: Any, caplog: pytest.LogCaptureFixture
+) -> None:
+    mock_processor = MagicMock()
+    mock_processor_class.return_value = mock_processor
+
+    run = build_run(
+        {
+            "type": "WEBHOOK",
+            "url": "http://localhost:8080/webhook",
+            "agent": True,
+            "body": {"custom": "body"},
+        }
+    )
+
+    with patch("streamers.polling.polling_streamer.HttpPollingConsumer"):
+        with caplog.at_level(
+            logging.WARNING, logger="streamers.polling.polling_streamer"
+        ):
+            PollingStreamer().process_run(run)
+
+    assert "does not look like a Port event" in caplog.text
+    assert "['custom']" in caplog.text
+
+
+@patch("streamers.polling.polling_streamer.PollingToWebhookProcessor")
+def test_polling_streamer_process_run_raises_when_url_is_missing(
+    mock_processor_class: Any,
+) -> None:
+    mock_processor = MagicMock()
+    mock_processor_class.return_value = mock_processor
+
+    run = build_run(
+        {
+            "type": "WEBHOOK",
+            "agent": True,
+            "body": event_with_invocation_method({}),
+        }
+    )
+
+    with patch("streamers.polling.polling_streamer.HttpPollingConsumer"):
+        with pytest.raises(ValueError, match="no invocation method type or url"):
+            PollingStreamer().process_run(run)
+
+    mock_processor.process_run.assert_not_called()
+
+
 # --- Workflow node run streamer tests ---
 
 
@@ -130,6 +282,35 @@ def test_polling_streamer_process_wf_node_run(
         assert invocation_method["url"] == "https://httpbin.org/post"
         assert invocation_method["synchronized"] is True
         assert "agent" not in invocation_method
+
+
+@patch("streamers.polling.polling_streamer.PollingToWebhookProcessor")
+def test_polling_streamer_process_wf_node_run_passes_the_whole_config(
+    mock_processor_class: Any,
+) -> None:
+    mock_processor = MagicMock()
+    mock_processor_class.return_value = mock_processor
+
+    node_run = {
+        "identifier": "wfnr_abc123",
+        "config": {
+            "type": "WEBHOOK",
+            "url": "https://httpbin.org/post",
+            "agent": True,
+            "body": {"service": "payments"},
+            "onTimeout": "continue",
+        },
+    }
+
+    with patch("streamers.polling.polling_streamer.HttpPollingConsumer"):
+        PollingStreamer().process_wf_node_run(node_run)
+
+    invocation_method = mock_processor.process_wf_node_run.call_args[0][1]
+    assert invocation_method["body"] == {"service": "payments"}
+    assert invocation_method["onTimeout"] == "continue"
+    assert invocation_method["method"] == "POST"
+    assert invocation_method["synchronized"] is False
+    assert "agent" not in invocation_method
 
 
 @patch("streamers.polling.polling_streamer.PollingToWebhookProcessor")


### PR DESCRIPTION
# Description

What - don't fail if no mapping aligns, fix polling schema to match kafka
Why - bug
How - use the incoming body and pass it through, make sure schema aligned

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

